### PR TITLE
RM7057 leave request : readonly fields

### DIFF
--- a/axelor-human-resource/src/main/resources/views/LeaveRequest.xml
+++ b/axelor-human-resource/src/main/resources/views/LeaveRequest.xml
@@ -33,7 +33,8 @@
 	</grid>
 	
 	<form name="leave-request-form" title="Leave Request" model="com.axelor.apps.hr.db.LeaveRequest"
-	    onNew="action-leave-request-record-default,action-leave-request-attrs-buttons, action-leave-request-record-to-justify" onLoad="action-leave-request-attrs-buttons,action-leave-request-attrs-draft-cancel,action-leave-request-attrs-select,action-leave-request-attrs-inject-change, action-leave-request-method-leave-reason-to-justify"
+	    onNew="action-leave-request-record-default,action-leave-request-attrs-buttons, action-leave-request-record-to-justify" 
+	    onLoad="action-leave-request-group-on-form-load"
 	    onSave="action-leave-request-validate-dates-on-save" canCopy="false">
 
 	    <panel sidebar="true" name="actions" title="Actions" stacked="true">
@@ -119,6 +120,16 @@
 		<action name="action-leave-request-attrs-draft-cancel"/>
 	</action-group>
 	
+	<action-group name="action-leave-request-group-on-form-load">
+		<action name="action-leave-request-attrs-buttons"/>	
+		<action name="action-leave-request-attrs-draft-cancel"/>
+		<action name="action-leave-request-attrs-select"/>
+		<action name="action-leave-request-attrs-inject-change"/>
+		<action name="action-leave-request-method-leave-reason-to-justify"/>
+		<action name="action-leave-request-attrs-send"/>
+		<action name="action-leave-request-attrs-valid-refuse"/>
+	</action-group>
+	
 	<action-record name="action-leave-request-record-default" model="com.axelor.apps.hr.db.LeaveRequest">
 	    <field name="user" expr="eval:__user__"/>
 	    <field name="company" expr="eval: __user__.activeCompany"/>
@@ -153,7 +164,7 @@
 	</action-attrs>
 	
 	<action-attrs name="action-leave-request-attrs-valid-refuse">
-  		<attribute name="readonly" expr="eval: statusSelect == 3 || statusSelect == 4 " for="information"/>
+  		<attribute name="readonly" expr="eval: true" if="statusSelect == 3 || statusSelect == 4" for="information"/>
 	</action-attrs>
 	
 	<action-attrs name="action-leave-request-attrs-draft-cancel">


### PR DESCRIPTION
Outside of draft status, fields are now set to read only after loading the
leave request form. A manager can still change them while the request
awaits validation.