### PR TITLE
RM7251: In BankOrder, new partner type select

### DIFF
--- a/axelor-bank-payment/src/main/resources/views/BankOrder.xml
+++ b/axelor-bank-payment/src/main/resources/views/BankOrder.xml
@@ -330,6 +330,7 @@
 		<attribute name="domain" for="partner" expr="self.isCustomer = true" if="_parent.partnerTypeSelect == 3"/>    
 		<attribute name="domain" for="partner" expr="self.isEmployee = true" if="_parent.partnerTypeSelect == 2"/>
 		<attribute name="domain" for="partner" expr="self.isSupplier = true" if="_parent.partnerTypeSelect == 1"/>
+		<attribute name="domain" for="partner" expr="self.isSupplier = false AND self.isEmployee = false AND self.isCustomer = false AND self.isContact = false" if="__parent__.partnerTypeSelect == 5"/>
     </action-attrs>
     
      <action-attrs name="action-bank-order-attrs-interbank-code-line-domain">

--- a/axelor-bank-payment/src/main/resources/views/Selects.xml
+++ b/axelor-bank-payment/src/main/resources/views/Selects.xml
@@ -34,6 +34,7 @@
 		<option value="2">Employee</option>
 		<option value="3">Customer</option>
 		<option value="4">Company</option>
+		<option value="5">Other</option>
 	</selection>
 	
 	<selection name="bankpayment.bank.order.status.select">


### PR DESCRIPTION
Added "Other" in the partner selection. If "Other" is selected, the
partner must not be a supplier, an employee a customer or a contact in
order to be selected in the lines.