### PR TITLE
RM7102: Average price in stock for Product

### DIFF
--- a/axelor-base/src/main/resources/views/Product.xml
+++ b/axelor-base/src/main/resources/views/Product.xml
@@ -125,6 +125,7 @@
 	      			</panel>
 	      			<panel colSpan="12" if-module="axelor-supplychain" if="__config__.app.isApp('supplychain')">
 				        <button name="showAllStockMoveLine" title="Show all stock move" colSpan="6" onClick="action-product-view-stock-move-line"/>
+						<field name="avgPrice"/>
 				        <spacer/>
 				        <panel-dashlet colSpan="12" action="action-product-view-stock"/>
 				        <panel-dashlet colSpan="12" action="action-stock-report-for-product"/>
@@ -251,6 +252,7 @@
     <action-group name="action-group-base-product-onnew">
    	 	<action name="action-product-attrs-scale-and-precision"/>
    	 	<action name="action-product-attrs-scale-and-precision-production"/>
+		<action name="action-product-attrs-scale-and-precision-stock"/>
     	<action name="action-product-record-default-new"/>
     	<action name="action-product-record-sale-supply-select"/>
     	<action name="action-product-record-in-ati"/>
@@ -276,6 +278,7 @@
     	<action name="action-product-attrs-readonly-unit"/>
         <action name="action-product-attrs-scale-and-precision"/>
         <action name="action-product-attrs-scale-and-precision-production"/>
+		<action name="action-product-attrs-scale-and-precision-stock"/>
         <action name="action-product-attrs-title-sale-price"/>
         <action name="action-product-set-stock"/>
         <action name="action-product-set-total-variants"/>

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/LocationLineServiceImpl.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/LocationLineServiceImpl.java
@@ -115,13 +115,13 @@ public class LocationLineServiceImpl implements LocationLineService {
 	
 	
 	public void checkStockMin(LocationLine locationLine, boolean isDetailLocationLine) throws AxelorException  {
-		if(!isDetailLocationLine && locationLine.getCurrentQty().compareTo(BigDecimal.ZERO) == -1 && locationLine.getLocation().getTypeSelect() == LocationRepository.TYPE_INTERNAL)  {
+		if(!isDetailLocationLine && locationLine.getCurrentQty().compareTo(BigDecimal.ZERO) == -1 && locationLine.getLocation().getTypeSelect() != LocationRepository.TYPE_VIRTUAL)  {
 			throw new AxelorException(String.format(I18n.get(IExceptionMessage.LOCATION_LINE_1), 
 					locationLine.getProduct().getName(), locationLine.getProduct().getCode()), IException.CONFIGURATION_ERROR);
 		}
 		else if(isDetailLocationLine && locationLine.getCurrentQty().compareTo(BigDecimal.ZERO) == -1 
-				&& ((locationLine.getLocation() != null && locationLine.getLocation().getTypeSelect() == LocationRepository.TYPE_INTERNAL)
-				    || (locationLine.getDetailsLocation() != null && locationLine.getDetailsLocation().getTypeSelect() == LocationRepository.TYPE_INTERNAL)))  {
+				&& ((locationLine.getLocation() != null && locationLine.getLocation().getTypeSelect() != LocationRepository.TYPE_VIRTUAL)
+				    || (locationLine.getDetailsLocation() != null && locationLine.getDetailsLocation().getTypeSelect() != LocationRepository.TYPE_VIRTUAL)))  {
 
 			String trackingNumber = "";
 			if(locationLine.getTrackingNumber() != null)  {

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/LocationService.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/LocationService.java
@@ -30,5 +30,7 @@ public interface LocationService {
 	public BigDecimal getRealQty(Long productId, Long locationId);
 	
 	public BigDecimal getFutureQty(Long productId, Long locationId);
+
+	public BigDecimal computeAvgPriceForProduct(Long productId);
 	
 }

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/LocationServiceImpl.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/LocationServiceImpl.java
@@ -21,9 +21,13 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import com.axelor.apps.base.db.repo.ProductRepository;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.stock.db.Location;
 import com.axelor.apps.stock.db.LocationLine;
+import com.axelor.apps.stock.db.repo.LocationLineRepository;
 import com.axelor.apps.stock.db.repo.LocationRepository;
+import com.axelor.db.JPA;
+import com.axelor.inject.Beans;
 import com.google.inject.Inject;
 
 public class LocationServiceImpl implements LocationService{
@@ -42,15 +46,15 @@ public class LocationServiceImpl implements LocationService{
 		return locationRepo.all().filter("self.isDefaultLocation = true AND self.typeSelect = ?1", LocationRepository.TYPE_INTERNAL).fetchOne();
 	}
 	
-	public List<Location> getInternalLocations() {
-		return locationRepo.all().filter("self.typeSelect = ?1", LocationRepository.TYPE_INTERNAL).fetch();
+	public List<Location> getNonVirtualLocations() {
+		return locationRepo.all().filter("self.typeSelect != ?1", LocationRepository.TYPE_VIRTUAL).fetch();
 	}
 	
 	@Override
 	public BigDecimal getQty(Long productId, Long locationId, String qtyType) {
 		if (productId != null) {
 			if (locationId == null) {
-				List<Location> locations = getInternalLocations();
+				List<Location> locations = getNonVirtualLocations();
 				if (!locations.isEmpty()) {
 					BigDecimal qty = BigDecimal.ZERO;
 					for (Location location : locations) {
@@ -84,5 +88,20 @@ public class LocationServiceImpl implements LocationService{
 		return getQty(productId, locationId, "future");
 	}
 
+	@Override
+	public BigDecimal computeAvgPriceForProduct(Long productId) {
+		String query = "SELECT new list(self.avgPrice, self.currentQty) FROM LocationLine as self " +
+				       "WHERE self.product.id = " + productId + " AND self.location.typeSelect != " + LocationRepository.TYPE_VIRTUAL;
+		int scale = Beans.get(AppBaseService.class).getNbDecimalDigitForUnitPrice();
+		BigDecimal avgPrice = BigDecimal.ZERO;
+		BigDecimal qtyTot = BigDecimal.ZERO;
+		List<List<BigDecimal>> results = JPA.em().createQuery(query).getResultList();
+		for (List<BigDecimal> result : results) {
+		    avgPrice = avgPrice.add(result.get(0).multiply(result.get(1)));
+		    qtyTot = qtyTot.add(result.get(1));
+		}
+		avgPrice = avgPrice.divide(qtyTot, scale, BigDecimal.ROUND_HALF_UP);
+		return avgPrice;
+	}
 	
 }

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveLineService.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveLineService.java
@@ -91,7 +91,9 @@ public interface StockMoveLineService {
 
 	public void updateLocations(Location fromLocation, Location toLocation, Product product, BigDecimal qty, int fromStatus, int toStatus, LocalDate
 			lastFutureStockMoveDate, TrackingNumber trackingNumber) throws AxelorException;
-	
+
+	public void updateAveragePriceLocationLine(Location location, StockMoveLine stockMoveLine, int toStatus);
+
 	public StockMoveLine compute(StockMoveLine stockMoveLine, StockMove stockMove) throws AxelorException;
 
 

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveLineServiceImpl.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveLineServiceImpl.java
@@ -35,6 +35,7 @@ import com.axelor.apps.stock.db.LocationLine;
 import com.axelor.apps.stock.db.StockMove;
 import com.axelor.apps.stock.db.StockMoveLine;
 import com.axelor.apps.stock.db.repo.LocationLineRepository;
+import com.axelor.apps.stock.db.repo.LocationRepository;
 import com.axelor.apps.stock.db.repo.StockMoveRepository;
 import com.axelor.exception.AxelorException;
 import com.axelor.inject.Beans;
@@ -257,6 +258,10 @@ public class StockMoveLineServiceImpl implements StockMoveLineService  {
 					qty = Beans.get(UnitConversionService.class).convertWithProduct(stockMoveLineUnit, productUnit, qty, stockMoveLine.getProduct());
 				}
 
+				if (toLocation.getTypeSelect() != LocationRepository.TYPE_VIRTUAL)  {
+					this.updateAveragePriceLocationLine(toLocation, stockMoveLine, toStatus);
+				}
+
 				this.updateLocations(fromLocation, toLocation, stockMoveLine.getProduct(), qty, fromStatus, toStatus,
 						lastFutureStockMoveDate, stockMoveLine.getTrackingNumber());
 			}
@@ -264,6 +269,52 @@ public class StockMoveLineServiceImpl implements StockMoveLineService  {
 
 	}
 
+	@Override
+	public void updateAveragePriceLocationLine(Location location, StockMoveLine stockMoveLine, int toStatus) {
+		if (toStatus == StockMoveRepository.STATUS_REALIZED) {
+			this.computeNewAveragePriceLocationLine(location, stockMoveLine);
+		}
+		else if (toStatus == StockMoveRepository.STATUS_CANCELED) {
+			this.cancelAveragePriceLocationLine(location, stockMoveLine);
+		}
+	}
+
+	protected void computeNewAveragePriceLocationLine(Location location, StockMoveLine stockMoveLine) {
+	    LocationLine locationLine = Beans.get(LocationLineService.class)
+				.getLocationLine(location, stockMoveLine.getProduct());
+	    int scale = Beans.get(AppBaseService.class).getNbDecimalDigitForUnitPrice();
+		BigDecimal oldAvgPrice = locationLine.getAvgPrice();
+		BigDecimal oldQty = locationLine.getCurrentQty();
+		BigDecimal newPrice = stockMoveLine.getUnitPriceUntaxed();
+		BigDecimal newQty = stockMoveLine.getRealQty();
+		BigDecimal newAvgPrice;
+		if (oldAvgPrice == null || oldQty == null || oldAvgPrice.equals(BigDecimal.ZERO) || oldQty.equals(BigDecimal.ZERO)) {
+		    oldAvgPrice = BigDecimal.ZERO;
+			oldQty = BigDecimal.ZERO;
+		}
+		BigDecimal sum = oldAvgPrice.multiply(oldQty);
+		sum = sum.add(newPrice.multiply(newQty));
+        newAvgPrice = sum.divide(oldQty.add(newQty), scale, RoundingMode.HALF_UP);
+        locationLine.setAvgPrice(newAvgPrice);
+	}
+
+	protected void cancelAveragePriceLocationLine(Location location, StockMoveLine stockMoveLine) {
+		LocationLine locationLine = Beans.get(LocationLineService.class)
+				.getLocationLine(location, stockMoveLine.getProduct());
+		int scale = Beans.get(AppBaseService.class).getNbDecimalDigitForUnitPrice();
+		BigDecimal currentAvgPrice = locationLine.getAvgPrice();
+		BigDecimal currentTotalQty = locationLine.getCurrentQty();
+
+		BigDecimal currentLinePrice = stockMoveLine.getUnitPriceUntaxed();
+		BigDecimal currentLineQty = stockMoveLine.getRealQty();
+
+		BigDecimal diff = currentTotalQty.multiply(currentAvgPrice).			//(currentAvgPrice*totalQty -
+				subtract(currentLinePrice.multiply(currentLineQty));			// currentLinePrice*currentLineQty)
+		BigDecimal updatedAvgPrice = 											// /  (totalQty - currentLineQty)
+				diff.divide(currentTotalQty.subtract(currentLineQty)
+				, scale, RoundingMode.HALF_UP);
+		locationLine.setAvgPrice(updatedAvgPrice);
+	}
 
 	@Override
 	public void updateLocations(Location fromLocation, Location toLocation, Product product, BigDecimal qty, int fromStatus, int toStatus, LocalDate

--- a/axelor-stock/src/main/resources/domains/LocationLine.xml
+++ b/axelor-stock/src/main/resources/domains/LocationLine.xml
@@ -12,6 +12,7 @@
 	<many-to-one name="product" ref="com.axelor.apps.base.db.Product" title="Product"/>    
 	<decimal name="currentQty" title="Current Qty"/>
 	<decimal name="futureQty" title="Future Qty"/>
+	<decimal name="avgPrice" precision="20" scale="10" readonly="true" title="Average Price"/>
 	<date name="lastFutureStockMoveDate" title="Last Future Stock Move"/>
 	
 	<many-to-one name="trackingNumber" ref="com.axelor.apps.base.db.TrackingNumber" title="Tracking Nbr"/>

--- a/axelor-stock/src/main/resources/domains/Product.xml
+++ b/axelor-stock/src/main/resources/domains/Product.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<domain-models xmlns="http://axelor.com/xml/ns/domain-models" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://axelor.com/xml/ns/domain-models http://axelor.com/xml/ns/domain-models/domain-models_5.0.xsd">
+ 
+  <module name="base" package="com.axelor.apps.base.db"/>
+ 
+  <entity name="Product" lang="java">
+      <decimal name="avgPrice" readonly="true" precision="20" scale="10" title="Average Price"/>
+  </entity>
+
+</domain-models>

--- a/axelor-stock/src/main/resources/i18n/messages.csv
+++ b/axelor-stock/src/main/resources/i18n/messages.csv
@@ -14,6 +14,7 @@
 "App stock",,,
 "Are you sure you want to realize this stock move?",,,
 "Arrivals History",,,
+"Average Price",,,
 "Basic",,,
 "Both source location address and delivery (to) address are required to define the delivery itinerary",,,
 "Cancel",,,

--- a/axelor-stock/src/main/resources/i18n/messages_en.csv
+++ b/axelor-stock/src/main/resources/i18n/messages_en.csv
@@ -14,6 +14,7 @@
 "App stock",,,
 "Are you sure you want to realize this stock move?",,,
 "Arrivals History",,,
+"Average Price",,,
 "Basic",,,
 "Both source location address and delivery (to) address are required to define the delivery itinerary",,,
 "Cancel",,,

--- a/axelor-stock/src/main/resources/i18n/messages_fr.csv
+++ b/axelor-stock/src/main/resources/i18n/messages_fr.csv
@@ -14,6 +14,7 @@
 "App stock",,,
 "Are you sure you want to realize this stock move?","Confirmer la réalisation de ce mouvement de stock?",,
 "Arrivals History","Historique réceptions",,
+"Average Price","Prix Moyen",,
 "Basic","Basique",,
 "Both source location address and delivery (to) address are required to define the delivery itinerary","Les champs Emplacement source et A l'adresse sont requis pour définir l'itinéraire de livraison.",,
 "Cancel","Annuler",,

--- a/axelor-stock/src/main/resources/views/Charts.xml
+++ b/axelor-stock/src/main/resources/views/Charts.xml
@@ -200,7 +200,7 @@
 							AND loc.type_select = 1) AS qty
 				FROM stock_location_line loc_line, stock_location location
 				WHERE loc_line.location = location.id 
-					AND location.type_select = 1 
+					AND location.type_select != 3
 					AND loc_line.product = :id
 				GROUP BY location.id) 
 		   		UNION ALL
@@ -250,7 +250,7 @@
 		   		stock_location_line loc_line, stock_location location
 		    WHERE 
 		        loc_line.location = location.id 
-				AND location.type_select = 1 
+				AND location.type_select != 3
 				AND loc_line.product = :id
 		    GROUP BY 
 		   		location.id) 

--- a/axelor-stock/src/main/resources/views/Dashboard.xml
+++ b/axelor-stock/src/main/resources/views/Dashboard.xml
@@ -138,7 +138,7 @@
 	<action-view name="action-product-view-stock" title="Stock" model="com.axelor.apps.stock.db.LocationLine">
     	<view type="grid" name="location-line-product-grid"/>
     	<view type="form" name="location-line-product-form"/>
-    	<domain>self.product.id = :id and self.location.typeSelect = 1</domain>
+    	<domain>self.product.id = :id and self.location.typeSelect != 3</domain>
     </action-view>
     
     <action-view name="action-stock-report-for-product" title="Stock" model="com.axelor.apps.stock.db.LocationLine">

--- a/axelor-stock/src/main/resources/views/LocationLine.xml
+++ b/axelor-stock/src/main/resources/views/LocationLine.xml
@@ -7,6 +7,7 @@
         <field name="product" form-view="product-form" grid-view="product-grid"/>
         <field name="currentQty" aggregate="sum"/>
         <field name="futureQty" aggregate="sum"/>
+        <field name="avgPrice" x-scale="2"/>
     </grid>
     
     <form name="location-line-form" title="Stock Location content" model="com.axelor.apps.stock.db.LocationLine">
@@ -14,6 +15,7 @@
 	        <field name="product" form-view="product-form" grid-view="product-grid"/>
 	        <field name="currentQty"/>
 	        <field name="futureQty"/>
+            <field name="avgPrice" x-scale="2"/>
         </panel>
     </form>
     
@@ -21,6 +23,7 @@
         <field name="location" form-view="location-form" grid-view="location-grid"/>
         <field name="currentQty" aggregate="sum"/>
         <field name="futureQty" aggregate="sum"/>
+        <field name="avgPrice" x-scale="2"/>
         <field name="lastFutureStockMoveDate"/>
     </grid>
     
@@ -29,6 +32,7 @@
 	        <field name="location" form-view="location-form" grid-view="location-grid"/>
 	        <field name="currentQty"/>
 	        <field name="futureQty"/>
+            <field name="avgPrice" x-scale="2"/>
 	        <field name="lastFutureStockMoveDate"/>
         </panel>
     </form>
@@ -37,6 +41,7 @@
         <field name="location" form-view="location-form" grid-view="location-grid"/>
         <field name="currentQty" aggregate="sum"/>
         <field name="futureQty" aggregate="sum"/>
+         <field name="avgPrice" x-scale="2"/>
         <field name="lastFutureStockMoveDate"/>
     </grid>
     
@@ -52,6 +57,7 @@
 	        <field name="product" form-view="product-form" grid-view="product-grid"/>
 	        <field name="currentQty"/>
 	        <field name="futureQty"/>
+            <field name="avgPrice" x-scale="2"/>
 	        <field name="trackingNumber"/>
         </panel>
     </form>

--- a/axelor-stock/src/main/resources/views/Product.xml
+++ b/axelor-stock/src/main/resources/views/Product.xml
@@ -6,7 +6,10 @@
     <action-record name="action-product-set-stock" model="com.axelor.apps.base.db.Product" if-module="axelor-stock">
         <field name="$realQty" expr="call:com.axelor.apps.stock.service.LocationService:getRealQty(id, null)" if="__config__.app.isApp('stock')" />
         <field name="$futureQty" expr="call:com.axelor.apps.stock.service.LocationService:getFutureQty(id, null)" if="__config__.app.isApp('stock')" />
+        <field name="avgPrice" expr="call:com.axelor.apps.stock.service.LocationService:computeAvgPriceForProduct(id)" if="__config__.app.isApp('stock')" />
     </action-record>
-    
-	
+
+    <action-attrs name="action-product-attrs-scale-and-precision-stock" if-module="axelor-stock">
+        <attribute name="scale" for="avgPrice" expr="eval: __config__.app.getNbDecimalDigitForUnitPrice()" />
+    </action-attrs>
 </object-views>

--- a/axelor-stock/src/main/resources/views/StockMoveLine.xml
+++ b/axelor-stock/src/main/resources/views/StockMoveLine.xml
@@ -9,8 +9,8 @@
         <field name="productModel" form-view="product-form" grid-view="product-grid"/>
         <field name="qty"  aggregate="sum" onChange="action-stock-move-line-record-qty, action-stock-move-line-compute-price"/>
         <field name="realQty" aggregate="sum"/>
-        <field name="unitPriceUntaxed"/>
-        <field name="unitPriceTaxed" hidden="true"/>
+        <field name="unitPriceUntaxed" x-scale="2"/>
+        <field name="unitPriceTaxed" x-scale="2" hidden="true"/>
         <field name="unit" form-view="unit-form" grid-view="unit-grid"/>
         <field name="trackingNumber"/>
         <field name="conformitySelect"/>
@@ -21,15 +21,15 @@
         <field name="product" readonly="true" form-view="product-form" grid-view="product-grid"/>
         <field name="productModel" readonly="true" form-view="product-form" grid-view="product-grid"/>
         <field name="qty" aggregate="sum"/>
-        <field name="unitPriceUntaxed"/>
-        <field name="unitPriceTaxed" hidden="true"/>
+        <field name="unitPriceUntaxed" x-scale="2"/>
+        <field name="unitPriceTaxed" x-scale="2" hidden="true"/>
         <field name="unit" readonly="true" form-view="unit-form" grid-view="unit-grid"/>
         <field name="trackingNumber" readonly="true"/>
         <field name="conformitySelect" readonly="true"/>
     </grid>
     
     <form name="stock-move-line-form" title="Stock move line" model="com.axelor.apps.stock.db.StockMoveLine"
-    	onNew="action-stock-move-line-record-new" onLoad="action-inventory-line-attrs-tracking-number, action-stock-move-line-attrs-show-unit-price-taxed" width="large">
+    	onNew="action-stock-move-line-record-new" onLoad="action-stock-move-line-attrs-scale-and-precision, action-inventory-line-attrs-tracking-number, action-stock-move-line-attrs-show-unit-price-taxed" width="large">
         <panel name="main" >
             <field name="productName" />
 	        <field name="product" domain="self.expense = false" onChange="action-group-stock-stockmoveline-product-onchange" onSelect="action-stock-move-line-product-domain" form-view="product-form" grid-view="product-grid"/>
@@ -53,8 +53,8 @@
         <field name="productModel" form-view="product-form" grid-view="product-grid"/>
         <field name="qty"  aggregate="sum" onChange="action-stock-move-line-record-qty, action-stock-move-line-compute-price"/>
         <field name="realQty" aggregate="sum"/>
-        <field name="unitPriceUntaxed"/>
-        <field name="unitPriceTaxed" hidden="true"/>
+        <field name="unitPriceUntaxed" x-scale="2"/>
+        <field name="unitPriceTaxed" x-scale="2" hidden="true"/>
         <field name="unit" form-view="unit-form" grid-view="unit-grid"/>
         <field name="trackingNumber"/>
         <field name="accordanceSelect"/>
@@ -70,7 +70,7 @@
         <field name="stockMove.partner"/>
         <field name="realQty" aggregate="sum"/>
         <field name="unitPriceUntaxed" x-scale="2"/>
-        <field name="unitPriceTaxed" hidden="true"/>
+        <field name="unitPriceTaxed" x-scale="2" hidden="true"/>
         <field name="unit" form-view="unit-form" grid-view="unit-grid"/>
         <field name="trackingNumber"/>
         <field name="stockMove.statusSelect"/>
@@ -107,8 +107,8 @@
         <field name="product" form-view="product-form" grid-view="product-grid"/>
         <field name="productModel" form-view="product-form" grid-view="product-grid"/>
         <field name="qty" title="Consumed quantity" aggregate="sum"/>
-        <field name="unitPriceUntaxed"/>
-        <field name="unitPriceTaxed" hidden="true"/>
+        <field name="unitPriceUntaxed" x-scale="2"/>
+        <field name="unitPriceTaxed" x-scale="2" hidden="true"/>
         <field name="unit" form-view="unit-form" grid-view="unit-grid"/>
         <field name="trackingNumber"/>
     </grid>
@@ -185,7 +185,6 @@
 	</action-attrs>
 	
 	<action-attrs name="action-stock-move-line-attrs-scale-and-precision">
-		<attribute name="scale" for="price" expr="eval: __config__.app.getNbDecimalDigitForUnitPrice()"/>
 		<attribute name="scale" for="unitPriceUntaxed" expr="eval: __config__.app.getNbDecimalDigitForUnitPrice()"/>
 	</action-attrs>
 	

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockMoveServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockMoveServiceSupplychainImpl.java
@@ -101,10 +101,5 @@ public class StockMoveServiceSupplychainImpl extends StockMoveServiceImpl  {
 
 		return newStockSeq;
 	}
-	
-	@Transactional(rollbackOn = {AxelorException.class, Exception.class})
-	public void computeProductWeightedAveragePrice(StockMove stockMove){
-		
-	}
 
 }


### PR DESCRIPTION
+ Added an average price in a Location Line.
+ The average price is updated with every stock move.
+ When a stock move is cancelled, the average price goes back to the
right value.
+ Added an average price in product. This average price comes from the
stock.
+ To get average price and total in stocks for product, we take into
account external and internal locations instead of just internal.
+ For prices in product/stock, and stock move line, the scale is setted
dynamically using the configuration when it is possible, otherwise we
use scale = 2.