### PR TITLE
Fix feature #8560 : Add counter in BankOrder menu

### DIFF
--- a/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/web/BankOrderController.java
+++ b/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/web/BankOrderController.java
@@ -227,4 +227,8 @@ public class BankOrderController {
 		response.setValue("senderBankDetails", bankDetails);
 	}
 
+	public String bankOrderAwaitingForSignatureMenuTag() {
+		return String.valueOf(bankOrderRepo.findAllByStatus(BankOrderRepository.STATUS_AWAITING_SIGNATURE).count());
+	}
+
 }

--- a/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/web/BankOrderController.java
+++ b/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/web/BankOrderController.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import com.axelor.apps.bankpayment.db.repo.EbicsUserRepository;
 import com.axelor.apps.base.db.BankDetails;
+import com.axelor.apps.base.db.Querie;
+import com.axelor.db.JPA;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -228,7 +230,8 @@ public class BankOrderController {
 	}
 
 	public String bankOrderAwaitingForSignatureMenuTag() {
-		return String.valueOf(bankOrderRepo.findAllByStatus(BankOrderRepository.STATUS_AWAITING_SIGNATURE).count());
+		return Long.toString(JPA.em().createQuery("SELECT COUNT(self) FROM BankOrder as self WHERE self.statusSelect = :statusSelect", Long.class)
+				.setParameter("statusSelect", BankOrderRepository.STATUS_AWAITING_SIGNATURE).getSingleResult());
 	}
 
 }

--- a/axelor-bank-payment/src/main/resources/domains/BankOrder.xml
+++ b/axelor-bank-payment/src/main/resources/domains/BankOrder.xml
@@ -42,8 +42,10 @@
 	<many-to-one name="signatoryEbicsUser" ref="com.axelor.apps.bankpayment.db.EbicsUser" title="Signatory"/>
 	<many-to-one name="generatedMetaFile" ref="com.axelor.meta.db.MetaFile" title="Generated file" />
 	<many-to-one name="signedMetaFile" ref="com.axelor.meta.db.MetaFile" title="Signed file" />
-	
-	 <extra-code><![CDATA[
+
+	  <finder-method name="findAllByStatus" all="true" using="statusSelect"/>
+
+	  <extra-code><![CDATA[
 	
 	   	// BANK ORDER TYPE SELECT
 		public static final int ORDER_TYPE_SEPA_CREDIT_TRANSFER = 1;
@@ -75,8 +77,8 @@
 		public static final int REJECT_STATUS_TOTALLY_REJECTED = 2;
 	
 	]]></extra-code>
-    
-    
+
+
   </entity>
 
 </domain-models>

--- a/axelor-bank-payment/src/main/resources/domains/BankOrder.xml
+++ b/axelor-bank-payment/src/main/resources/domains/BankOrder.xml
@@ -43,8 +43,6 @@
 	<many-to-one name="generatedMetaFile" ref="com.axelor.meta.db.MetaFile" title="Generated file" />
 	<many-to-one name="signedMetaFile" ref="com.axelor.meta.db.MetaFile" title="Signed file" />
 
-	  <finder-method name="findAllByStatus" all="true" using="statusSelect"/>
-
 	  <extra-code><![CDATA[
 	
 	   	// BANK ORDER TYPE SELECT

--- a/axelor-bank-payment/src/main/resources/views/Menu.xml
+++ b/axelor-bank-payment/src/main/resources/views/Menu.xml
@@ -102,7 +102,9 @@
 	
 	<menuitem name="account-root-bank-order-awaiting-for-signature"
 		parent="account-root-bank-orders" title="Bank Orders awaiting for signature"
-		action="account.bank.order.awaiting.for.signature" />
+		action="account.bank.order.awaiting.for.signature"
+		tag-get="com.axelor.apps.bankpayment.web.BankOrderController:bankOrderAwaitingForSignatureMenuTag()"
+		tag-style="default"/>
 	
 	<action-view name="account.bank.order.awaiting.for.signature"
 		title="Bank Orders awaiting for signature" model="com.axelor.apps.bankpayment.db.BankOrder" >


### PR DESCRIPTION
* Add a counter tag in account-root-bank-order-awaiting-for-signature
for show number of Bank Orders awaiting for signature.