### PR TITLE
Use sequence for drafts instead of hard coded numberin

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/ReconcileSequenceService.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/ReconcileSequenceService.java
@@ -20,6 +20,7 @@ package com.axelor.apps.account.service;
 import com.axelor.apps.account.db.Reconcile;
 import com.axelor.apps.account.db.repo.ReconcileRepository;
 import com.axelor.apps.account.exception.IExceptionMessage;
+import com.axelor.apps.base.db.Company;
 import com.axelor.apps.base.db.IAdministration;
 import com.axelor.apps.base.service.administration.GeneralServiceImpl;
 import com.axelor.apps.base.service.administration.SequenceService;
@@ -57,17 +58,22 @@ public class ReconcileSequenceService {
 		return seq;
 	}
 
-	public void setDraftSequence(Reconcile reconcile)  {		
+	public void setDraftSequence(Reconcile reconcile) throws AxelorException  {
 			
 		if (reconcile.getId() != null && Strings.isNullOrEmpty(reconcile.getReconcileSeq())
 			&& reconcile.getStatusSelect() == ReconcileRepository.STATUS_DRAFT)  {		
-			reconcile.setReconcileSeq(this.getDraftSequence(reconcile));		
+			reconcile.setReconcileSeq(this.getDraftSequence(reconcile.getDebitMoveLine().getMove().getCompany()));
 		}		
 		
 	}	
 	
-	protected String getDraftSequence(Reconcile reconcile)  {		
-		return "*" + reconcile.getId();		
+	protected String getDraftSequence(Company company) throws AxelorException  {
+		String seq = sequenceService.getSequenceNumber(IAdministration.DOCUMENT_DRAFT, company);
+		if (seq == null)  {
+			throw new AxelorException(String.format(I18n.get(com.axelor.apps.base.exceptions.IExceptionMessage.DRAFT_SEQUENCE_1),company.getName()),
+							IException.CONFIGURATION_ERROR);
+		}
+		return seq;
 	}		
 	
 }

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/InvoiceService.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/InvoiceService.java
@@ -136,7 +136,7 @@ public interface InvoiceService {
 	public Invoice createRefund(Invoice invoice) throws AxelorException;
 	
 	
-	public void setDraftSequence(Invoice invoice);
+	public void setDraftSequence(Invoice invoice) throws AxelorException;
 	
 	
 	public void generateBudgetDistribution(Invoice invoice);

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/workflow/ventilate/VentilateState.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/workflow/ventilate/VentilateState.java
@@ -21,16 +21,19 @@ import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
 import java.util.List;
 
-import com.axelor.apps.account.db.*;
-import com.axelor.apps.account.service.AccountingSituationService;
-import com.axelor.apps.account.service.JournalService;
-import com.axelor.inject.Beans;
 import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.axelor.apps.account.db.Account;
+import com.axelor.apps.account.db.AccountConfig;
+import com.axelor.apps.account.db.AccountingSituation;
+import com.axelor.apps.account.db.Invoice;
+import com.axelor.apps.account.db.Move;
 import com.axelor.apps.account.db.repo.InvoiceRepository;
 import com.axelor.apps.account.exception.IExceptionMessage;
+import com.axelor.apps.account.service.AccountingSituationService;
+import com.axelor.apps.account.service.JournalService;
 import com.axelor.apps.account.service.config.AccountConfigService;
 import com.axelor.apps.account.service.invoice.InvoiceToolService;
 import com.axelor.apps.account.service.invoice.workflow.WorkflowInvoice;
@@ -41,6 +44,7 @@ import com.axelor.apps.base.service.administration.SequenceService;
 import com.axelor.exception.AxelorException;
 import com.axelor.exception.db.IException;
 import com.axelor.i18n.I18n;
+import com.axelor.inject.Beans;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -217,8 +221,7 @@ public class VentilateState extends WorkflowInvoice {
 	 * @throws AxelorException
 	 */
 	protected void setInvoiceId( Sequence sequence ) throws AxelorException {
-
-		if ( !Strings.isNullOrEmpty(invoice.getInvoiceId()) && !invoice.getInvoiceId().contains("*") ) { return; }
+		if( !Strings.isNullOrEmpty(invoice.getInvoiceId()) && invoice.getStatusSelect() != InvoiceRepository.STATUS_DRAFT && invoice.getStatusSelect() != InvoiceRepository.STATUS_VALIDATED ) { return; }
 
 		invoice.setInvoiceId( sequenceService.setRefDate( invoice.getInvoiceDate() ).getSequenceNumber(sequence) );
 

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveCreateService.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveCreateService.java
@@ -151,7 +151,6 @@ public class MoveCreateService {
 		move.setPaymentMode(paymentMode);
 		move.setTechnicalOriginSelect(technicalOriginSelect);
 		moveRepository.save(move);
-		move.setReference("*"+move.getId());
 
 		return move;
 

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveSequenceService.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveSequenceService.java
@@ -20,7 +20,12 @@ package com.axelor.apps.account.service.move;
 import com.axelor.apps.account.db.Journal;
 import com.axelor.apps.account.db.Move;
 import com.axelor.apps.account.db.repo.MoveRepository;
+import com.axelor.apps.base.db.Company;
+import com.axelor.apps.base.db.IAdministration;
 import com.axelor.apps.base.service.administration.SequenceService;
+import com.axelor.exception.AxelorException;
+import com.axelor.exception.db.IException;
+import com.axelor.i18n.I18n;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
 
@@ -36,15 +41,20 @@ public class MoveSequenceService {
 	}
 
 	
-	protected String getDraftSequence(Move move)  {		
-		return "*" + move.getId();		
+	protected String getDraftSequence(Company company) throws AxelorException  {
+		String seq = sequenceService.getSequenceNumber(IAdministration.DOCUMENT_DRAFT, company);
+		if (seq == null)  {
+			throw new AxelorException(String.format(I18n.get(com.axelor.apps.base.exceptions.IExceptionMessage.DRAFT_SEQUENCE_1),company.getName()),
+							IException.CONFIGURATION_ERROR);
+		}
+		return seq;
 	}		
 			
-	public void setDraftSequence(Move move)  {		
+	public void setDraftSequence(Move move) throws AxelorException  {
 			
 		if (move.getId() != null && Strings.isNullOrEmpty(move.getReference())
 			&& move.getStatusSelect() == MoveRepository.STATUS_DRAFT)  {		
-			move.setReference(this.getDraftSequence(move));		
+			move.setReference(this.getDraftSequence(move.getCompany()));
 		}		
 		
 	}		

--- a/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/service/bankorder/BankOrderService.java
+++ b/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/service/bankorder/BankOrderService.java
@@ -55,7 +55,7 @@ public interface BankOrderService {
 	public File generateFile(BankOrder bankOrder) throws JAXBException, IOException, AxelorException, DatatypeConfigurationException;
 	
 	@Transactional(rollbackOn = {AxelorException.class, Exception.class})
-	public BankOrder generateSequence(BankOrder bankOrder);
+	public BankOrder generateSequence(BankOrder bankOrder) throws AxelorException;
 	
 	public void checkLines(BankOrder bankOrder)throws AxelorException;
 	

--- a/axelor-base/src/main/java/com/axelor/apps/base/db/IAdministration.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/db/IAdministration.java
@@ -78,6 +78,7 @@ public interface IAdministration {
 	static final String PURCHASE_INTERFACE = "purchaseInterface";
 	static final String MOVE_LINE_EXPORT = "moveLineExport";
 	static final String DOUBTFUL_CUSTOMER = "doubtfulCustomer";
+	static final String DOCUMENT_DRAFT = "documentDraft";
 	static final String SALES_ORDER = "saleOrder";
 	static final String PURCHASE_ORDER = "purchaseOrder";
 	static final String EVENT_TICKET = "eventTicket";

--- a/axelor-base/src/main/java/com/axelor/apps/base/exceptions/IExceptionMessage.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/exceptions/IExceptionMessage.java
@@ -198,4 +198,9 @@ public interface IExceptionMessage {
 	 */
 	static final public String PRODUCT_1 = /*$$(*/ "Variants generated" /*)*/;
 	static final public String PRODUCT_2 = /*$$(*/ "Prices updated" /*)*/;
+
+	/**
+	 * Draft sequence handling
+	 */
+	static final public String DRAFT_SEQUENCE_1 = /*$$(*/ "There is no sequence set for document drafts" /*)*/;
 }

--- a/axelor-base/src/main/resources/i18n/messages.csv
+++ b/axelor-base/src/main/resources/i18n/messages.csv
@@ -511,6 +511,7 @@
 "Discount/Additionnal/Replace",,,
 "Distribution precisions (POB, Village...)",,,
 "Document concerned",,,
+"Document draft",,,
 "Documents",,,
 "Dr",,,
 "Draft",,,

--- a/axelor-base/src/main/resources/i18n/messages_en.csv
+++ b/axelor-base/src/main/resources/i18n/messages_en.csv
@@ -511,6 +511,7 @@
 "Discount/Additionnal/Replace",,,
 "Distribution precisions (POB, Village...)",,,
 "Document concerned",,,
+"Document draft",,,
 "Documents",,,
 "Dr",,,
 "Draft",,,

--- a/axelor-base/src/main/resources/i18n/messages_fr.csv
+++ b/axelor-base/src/main/resources/i18n/messages_fr.csv
@@ -511,6 +511,7 @@
 "Discount/Additionnal/Replace","Remise/Surcharge/Remplace",,
 "Distribution precisions (POB, Village...)","Précisions de distribution (BP, Lieu-dit…)",,
 "Document concerned","Document concerné",,
+"Document draft","Brouillon de document",,
 "Documents",,,
 "Dr","Dr",,
 "Draft","Brouillon",,

--- a/axelor-base/src/main/resources/views/Selects.xml
+++ b/axelor-base/src/main/resources/views/Selects.xml
@@ -355,6 +355,7 @@
 		<option value="bankOrder">Bank order</option>
 		<option value="reconcile">Reconcile</option>
 		<option value="expense">Expense</option>
+		<option value="documentDraft">Document draft</option>
 	</selection>
 
 	<selection name="company.paybox.hash.select">

--- a/axelor-business-project/src/main/java/com/axelor/apps/businessproject/service/ExpenseServiceProjectImpl.java
+++ b/axelor-business-project/src/main/java/com/axelor/apps/businessproject/service/ExpenseServiceProjectImpl.java
@@ -27,6 +27,7 @@ import com.axelor.apps.account.service.AnalyticMoveLineService;
 import com.axelor.apps.account.service.move.MoveLineService;
 import com.axelor.apps.account.service.move.MoveService;
 import com.axelor.apps.base.service.administration.GeneralService;
+import com.axelor.apps.base.service.administration.SequenceService;
 import com.axelor.apps.hr.db.ExpenseLine;
 import com.axelor.apps.hr.db.repo.ExpenseRepository;
 import com.axelor.apps.hr.service.config.AccountConfigHRService;
@@ -42,9 +43,10 @@ public class ExpenseServiceProjectImpl extends ExpenseServiceImpl  {
 	public ExpenseServiceProjectImpl(MoveService moveService, ExpenseRepository expenseRepository, MoveLineService moveLineService,
 			AccountManagementServiceAccountImpl accountManagementService, GeneralService generalService,
 			AccountConfigHRService accountConfigService, AnalyticMoveLineService analyticMoveLineService,
-			HRConfigService hrConfigService, TemplateMessageService templateMessageService) {
+			HRConfigService hrConfigService, TemplateMessageService templateMessageService,
+			SequenceService sequenceService) {
 		
-		super(moveService, expenseRepository, moveLineService, accountManagementService, generalService, accountConfigService, analyticMoveLineService, hrConfigService, templateMessageService);
+		super(moveService, expenseRepository, moveLineService, accountManagementService, generalService, accountConfigService, analyticMoveLineService, hrConfigService, templateMessageService, sequenceService);
 	
 	}
 

--- a/axelor-business-project/src/main/java/com/axelor/apps/businessproject/service/InvoiceServiceProjectImpl.java
+++ b/axelor-business-project/src/main/java/com/axelor/apps/businessproject/service/InvoiceServiceProjectImpl.java
@@ -28,6 +28,7 @@ import com.axelor.apps.account.service.invoice.factory.CancelFactory;
 import com.axelor.apps.account.service.invoice.factory.ValidateFactory;
 import com.axelor.apps.account.service.invoice.factory.VentilateFactory;
 import com.axelor.apps.base.service.administration.GeneralService;
+import com.axelor.apps.base.service.administration.SequenceService;
 import com.axelor.apps.base.service.alarm.AlarmEngineService;
 import com.axelor.apps.businessproject.report.IReport;
 import com.axelor.apps.report.engine.ReportSettings;
@@ -41,8 +42,8 @@ public class InvoiceServiceProjectImpl extends InvoiceServiceImpl {
 	@Inject
 	public InvoiceServiceProjectImpl(ValidateFactory validateFactory, VentilateFactory ventilateFactory,
 			CancelFactory cancelFactory, AlarmEngineService<Invoice> alarmEngineService, InvoiceRepository invoiceRepo,
-			GeneralService generalService) {
-		super(validateFactory, ventilateFactory, cancelFactory, alarmEngineService, invoiceRepo, generalService);
+			GeneralService generalService, SequenceService sequenceService) {
+		super(validateFactory, ventilateFactory, cancelFactory, alarmEngineService, invoiceRepo, generalService, sequenceService);
 	}
 	
 	

--- a/axelor-demo-en/src/main/resources/data-demo/input/base_sequence.csv
+++ b/axelor-demo-en/src/main/resources/data-demo/input/base_sequence.csv
@@ -78,3 +78,4 @@
 9;"productTrackingNumber";"Tracking N°";1;5;"TN";;1;0;1
 10;"productionOrder";"Production Order N°";1;5;"PDO";;1;0;1
 11;"manufOrder";"Manufacturing Order N°";1;5;"MO";;1;0;1
+12;"documentDraft";"Draft";1;8;"DRFT";;1;0;1

--- a/axelor-demo-fr/src/main/resources/data-demo/input/base_sequence.csv
+++ b/axelor-demo-fr/src/main/resources/data-demo/input/base_sequence.csv
@@ -78,3 +78,4 @@
 9;"productTrackingNumber";"N° de suivi";1;5;"NS";;1;0;1
 10;"productionOrder";"Ordre de production";1;5;"OP";;1;0;1
 11;"manufOrder";"Ordre de fabrication";1;5;"OF";;1;0;1
+12;"documentDraft";"Brouillon de document";1;8;"BRLN";;1;0;1

--- a/axelor-human-resource/src/main/java/com/axelor/apps/hr/db/repo/ExpenseHRRepository.java
+++ b/axelor-human-resource/src/main/java/com/axelor/apps/hr/db/repo/ExpenseHRRepository.java
@@ -17,6 +17,8 @@
  */
 package com.axelor.apps.hr.db.repo;
 
+import javax.persistence.PersistenceException;
+
 import com.axelor.apps.hr.db.Expense;
 import com.axelor.apps.hr.service.expense.ExpenseService;
 import com.axelor.inject.Beans;
@@ -24,9 +26,12 @@ import com.axelor.inject.Beans;
 public class ExpenseHRRepository extends ExpenseRepository {
     @Override
     public Expense save(Expense expense) {
+		try {
         expense = super.save(expense);
         Beans.get(ExpenseService.class).setDraftSequence(expense);
-
+		} catch (Exception e) {
+			throw new PersistenceException(e.getLocalizedMessage());
+		}
         return expense;
     }
 }

--- a/axelor-human-resource/src/main/java/com/axelor/apps/hr/service/expense/ExpenseService.java
+++ b/axelor-human-resource/src/main/java/com/axelor/apps/hr/service/expense/ExpenseService.java
@@ -80,5 +80,5 @@ public interface ExpenseService  {
 	public BigDecimal computePersonalExpenseAmount(Expense expense);
 	public BigDecimal computeAdvanceAmount(Expense expense);
 
-	public void setDraftSequence(Expense expense);
+	public void setDraftSequence(Expense expense) throws AxelorException;
 }

--- a/axelor-purchase/src/main/java/com/axelor/apps/purchase/service/PurchaseOrderService.java
+++ b/axelor-purchase/src/main/java/com/axelor/apps/purchase/service/PurchaseOrderService.java
@@ -82,9 +82,9 @@ public interface PurchaseOrderService {
 
 	String getSequence(Company company) throws AxelorException ;
 
-	public String getDraftSequence(Long purchaseOrderId);
+	public String getDraftSequence(Company company) throws AxelorException;
 	
-	public void setDraftSequence(PurchaseOrder purchaseOrder);
+	public void setDraftSequence(PurchaseOrder purchaseOrder) throws AxelorException;
 
 	@Transactional(rollbackOn = {AxelorException.class, Exception.class})
 	public Partner validateSupplier(PurchaseOrder purchaseOrder);

--- a/axelor-purchase/src/main/java/com/axelor/apps/purchase/service/PurchaseOrderServiceImpl.java
+++ b/axelor-purchase/src/main/java/com/axelor/apps/purchase/service/PurchaseOrderServiceImpl.java
@@ -210,8 +210,13 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
 	}
 
 	@Override
-	public String getDraftSequence(Long purchaseOrderId){
-		return "*"+purchaseOrderId.toString();
+	public String getDraftSequence(Company company) throws AxelorException{
+		String seq = sequenceService.getSequenceNumber(IAdministration.DOCUMENT_DRAFT, company);
+		if (seq == null)  {
+			throw new AxelorException(String.format(I18n.get(com.axelor.apps.base.exceptions.IExceptionMessage.DRAFT_SEQUENCE_1),company.getName()),
+					IException.CONFIGURATION_ERROR);
+		}
+		return seq;
 	}
 
 	@Override
@@ -337,10 +342,10 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
 	}
 
 	@Override
-	public void setDraftSequence(PurchaseOrder purchaseOrder) {
+	public void setDraftSequence(PurchaseOrder purchaseOrder) throws AxelorException {
 		
 		if(purchaseOrder.getId() != null && Strings.isNullOrEmpty(purchaseOrder.getPurchaseOrderSeq())){
-			purchaseOrder.setPurchaseOrderSeq(this.getDraftSequence(purchaseOrder.getId()));
+			purchaseOrder.setPurchaseOrderSeq(this.getDraftSequence(purchaseOrder.getCompany()));
 		}
 	}
 	

--- a/axelor-sale/src/main/java/com/axelor/apps/sale/db/repo/SaleOrderManagementRepository.java
+++ b/axelor-sale/src/main/java/com/axelor/apps/sale/db/repo/SaleOrderManagementRepository.java
@@ -54,9 +54,10 @@ public class SaleOrderManagementRepository extends SaleOrderRepository {
 	@Override
 	public SaleOrder save(SaleOrder saleOrder) {
 		try {
-			computeSeq(saleOrder);
+			saleOrder = super.save(saleOrder);
+			Beans.get(SaleOrderService.class).setDraftSequence(saleOrder);
 			computeFullName(saleOrder);
-			return super.save(saleOrder);
+			return saleOrder;
 		} catch (Exception e) {
 			throw new PersistenceException(e.getLocalizedMessage());
 		}

--- a/axelor-sale/src/main/java/com/axelor/apps/sale/db/repo/SaleOrderManagementRepository.java
+++ b/axelor-sale/src/main/java/com/axelor/apps/sale/db/repo/SaleOrderManagementRepository.java
@@ -63,27 +63,13 @@ public class SaleOrderManagementRepository extends SaleOrderRepository {
 		}
 	}
 	
-	public void computeSeq(SaleOrder saleOrder){
-		try{
-			
-			if((saleOrder.getSaleOrderSeq() == null || Strings.isNullOrEmpty(saleOrder.getSaleOrderSeq())) && !saleOrder.getTemplate()){
-				if ( saleOrder.getStatusSelect() == ISaleOrder.STATUS_DRAFT ){
-					saleOrder.setSaleOrderSeq("*" + saleOrder.getId().toString());
-				}
-			}
-				
-		}
-		catch (Exception e) {
-			throw new PersistenceException(e.getLocalizedMessage());
-		}
-	}
-	
 	public void computeFullName(SaleOrder saleOrder){
 		try{
-			if(!Strings.isNullOrEmpty(saleOrder.getSaleOrderSeq()))
+			if(!Strings.isNullOrEmpty(saleOrder.getSaleOrderSeq())) {
 				saleOrder.setFullName(saleOrder.getSaleOrderSeq()+"-"+saleOrder.getClientPartner().getName());
-			else
+			} else {
 				saleOrder.setFullName(saleOrder.getClientPartner().getName());
+		}
 		}
 		catch (Exception e) {
 			throw new PersistenceException(e.getLocalizedMessage());

--- a/axelor-sale/src/main/java/com/axelor/apps/sale/service/SaleOrderService.java
+++ b/axelor-sale/src/main/java/com/axelor/apps/sale/service/SaleOrderService.java
@@ -108,8 +108,7 @@ public interface SaleOrderService {
 	
 	public String getReportLink(SaleOrder saleOrder, String name, String language, String format) throws AxelorException;
 
-
-	public void setDraftSequence(SaleOrder saleOrder);
+	public void setDraftSequence(SaleOrder saleOrder) throws AxelorException;
 }
 
 

--- a/axelor-sale/src/main/java/com/axelor/apps/sale/service/SaleOrderService.java
+++ b/axelor-sale/src/main/java/com/axelor/apps/sale/service/SaleOrderService.java
@@ -107,6 +107,9 @@ public interface SaleOrderService {
 	public SaleOrder computeEndOfValidityDate(SaleOrder saleOrder);
 	
 	public String getReportLink(SaleOrder saleOrder, String name, String language, String format) throws AxelorException;
+
+
+	public void setDraftSequence(SaleOrder saleOrder);
 }
 
 

--- a/axelor-sale/src/main/java/com/axelor/apps/sale/service/SaleOrderServiceImpl.java
+++ b/axelor-sale/src/main/java/com/axelor/apps/sale/service/SaleOrderServiceImpl.java
@@ -215,19 +215,24 @@ public class SaleOrderServiceImpl implements SaleOrderService {
 		return seq;
 	}
 
-	protected String getDraftSequence(SaleOrder saleOrder)  {
-		return "*" + saleOrder.getId();
+	protected String getDraftSequence(Company company) throws AxelorException  {
+		String seq = sequenceService.getSequenceNumber(IAdministration.DOCUMENT_DRAFT, company);
+		if (seq == null)  {
+			throw new AxelorException(String.format(I18n.get(com.axelor.apps.base.exceptions.IExceptionMessage.DRAFT_SEQUENCE_1),company.getName()),
+							IException.CONFIGURATION_ERROR);
+		}
+		return seq;
 	}
 
+
 	@Override
-	public void setDraftSequence(SaleOrder saleOrder)  {
+	public void setDraftSequence(SaleOrder saleOrder) throws AxelorException {
 		if(Strings.isNullOrEmpty(saleOrder.getSaleOrderSeq()) && !saleOrder.getTemplate()){
 			if ( saleOrder.getStatusSelect() == ISaleOrder.STATUS_DRAFT ){
-				saleOrder.setSaleOrderSeq(getDraftSequence(saleOrder));
+				saleOrder.setSaleOrderSeq(getDraftSequence(saleOrder.getCompany()));
 			}
 		}
 	}
-
 
 	@Override
 	public SaleOrder createSaleOrder(Company company) throws AxelorException{

--- a/axelor-sale/src/main/java/com/axelor/apps/sale/service/SaleOrderServiceImpl.java
+++ b/axelor-sale/src/main/java/com/axelor/apps/sale/service/SaleOrderServiceImpl.java
@@ -56,6 +56,7 @@ import com.axelor.exception.AxelorException;
 import com.axelor.exception.db.IException;
 import com.axelor.i18n.I18n;
 import com.axelor.inject.Beans;
+import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
@@ -212,6 +213,19 @@ public class SaleOrderServiceImpl implements SaleOrderService {
 							IException.CONFIGURATION_ERROR);
 		}
 		return seq;
+	}
+
+	protected String getDraftSequence(SaleOrder saleOrder)  {
+		return "*" + saleOrder.getId();
+	}
+
+	@Override
+	public void setDraftSequence(SaleOrder saleOrder)  {
+		if(Strings.isNullOrEmpty(saleOrder.getSaleOrderSeq()) && !saleOrder.getTemplate()){
+			if ( saleOrder.getStatusSelect() == ISaleOrder.STATUS_DRAFT ){
+				saleOrder.setSaleOrderSeq(getDraftSequence(saleOrder));
+			}
+		}
 	}
 
 


### PR DESCRIPTION
This patch series add a new kind of sequence for draft documents numbering (any kind). This solves issues #455 and all issues related to invalid character. This a different approach from #594 as it does not hardcode anything.