### PR TITLE
RM9213: Rework mass stock move UI

### DIFF
--- a/axelor-stock/src/main/resources/views/StockMove.xml
+++ b/axelor-stock/src/main/resources/views/StockMove.xml
@@ -37,7 +37,7 @@
         <button name="printStockMove" title="Print" icon="fa-print" onClick="action-print-stock-move" readonlyIf="statusSelect == 1"/>
         <button name="viewDirection" icon="fa-location-arrow" help="View Direction" onClick="action-stock-move-validate-address,action-stock-move-method-view-direction" readonlyIf="typeSelect != 2 || statusSelect == 1"/>
     </grid>
-    
+
     <grid name="stock-move-in-grid" title="Stock moves" model="com.axelor.apps.stock.db.StockMove" orderBy="-estimatedDate">
     	<toolbar>
 			<button name="printStockMoveGrid" title="Print StockMove(s)" onClick="action-print-stock-move" icon="fa-print"/>
@@ -56,6 +56,32 @@
         <button name="viewDirection" icon="fa-location-arrow" help="View Direction" onClick="action-stock-move-validate-address,action-stock-move-method-view-direction" readonlyIf="typeSelect != 2 || statusSelect == 1"/>
     </grid>
     
+    <grid name="stock-move-out-grid-mass" title="Stock moves" model="com.axelor.apps.stock.db.StockMove" orderBy="-estimatedDate">
+        <field name="stockMoveSeq"/>
+        <field name="fromLocation" form-view="location-form" grid-view="location-grid"/>
+        <field name="partner"  form-view="partner-form" grid-view="partner-grid" title="Client"/>
+        <field name="toLocation" form-view="location-form" grid-view="location-grid" hidden="true"/>
+        <field name="estimatedDate"/>
+        <field name="realDate"/>
+        <field name="company" form-view="company-form" grid-view="company-grid"/>
+        <field name="statusSelect"/>
+        <field name="typeSelect" hidden="true" />
+        <field name="toAddress" hidden="true" form-view="address-form" grid-view="address-grid"/>
+	</grid>
+    
+    <grid name="stock-move-in-grid-mass" title="Stock moves" model="com.axelor.apps.stock.db.StockMove" orderBy="-estimatedDate">
+        <field name="stockMoveSeq"/>
+        <field name="fromLocation" form-view="location-form" grid-view="location-grid" hidden="true"/>
+        <field name="partner"  form-view="partner-form" grid-view="partner-grid" title="Fournisseur"/>
+        <field name="toLocation" form-view="location-form" grid-view="location-grid"/>
+        <field name="estimatedDate"/>
+        <field name="realDate"/>
+        <field name="company" form-view="company-form" grid-view="company-grid"/>
+        <field name="statusSelect"/>
+        <field name="typeSelect" hidden="true" />
+        <field name="toAddress" hidden="true" form-view="address-form" grid-view="address-grid"/>
+	</grid>
+	
 	<form name="stock-move-form" title="Stock move" model="com.axelor.apps.stock.db.StockMove"
 		 onLoad="action-stock-move-attrs-typeselect-change" onNew="action-group-stock-stockmove-onnew">
 	  <panel name="main">

--- a/axelor-supplychain/src/main/resources/views/StockMove.xml
+++ b/axelor-supplychain/src/main/resources/views/StockMove.xml
@@ -3,22 +3,23 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://axelor.com/xml/ns/object-views http://axelor.com/xml/ns/object-views/object-views_4.1.xsd">
 
-	<form name="stock-move-multi-sale-invoicing-form" model="com.axelor.apps.stock.db.StockMove" title="Mass Cust. Stock Move Invoicing" >
-		<panel-related field="$customerStockMoveToInvoice" title="Customer Stock Move to invoice" colSpan="12" type="many-to-many" target="com.axelor.apps.stock.db.StockMove" domain="self.statusSelect = 3 AND self.typeSelect = 2" canNew="false" canEdit="false"/>
-		<panel sidebar="true" name="actions" title="Actions">
-			<button name="generateInvoiceConcatStockMove" title="Generate single invoice" onClick="action-validate-supplychain-outgoing-stock-move-check-selection,action-supplychain-stock-move-method-generate-concat-invoice"/>
-			<button name="generateMultiInvoice" title="Generate one invoice per outgoing stockMove" onClick="action-validate-supplychain-outgoing-stock-move-check-selection,action-supplychain-stock-move-method-generate-multi-invoice"/>
-	  	</panel>
-    </form>
+	<form name="stock-move-multi-sale-invoicing-form" model="com.axelor.apps.stock.db.StockMove" title="Mass Cust. Stock Move Invoicing" width="large" >
+		<panel name="actions" title="Actions">			
+			<button name="generateMultiInvoice" colSpan="6" title="Generate one invoice per outgoing stockMove" onClick="action-validate-supplychain-outgoing-stock-move-check-selection,action-supplychain-stock-move-method-generate-multi-invoice" readonlyIf="!customerStockMoveToInvoice || customerStockMoveToInvoice.length &lt; 2"/>
+			<button name="generateInvoiceConcatStockMove" colSpan="6" title="Generate single invoice" onClick="action-validate-supplychain-outgoing-stock-move-check-selection,action-supplychain-stock-move-method-generate-concat-invoice" readonlyIf="!customerStockMoveToInvoice || customerStockMoveToInvoice.length == 0"/>
+		</panel>
+		<panel-related height="17" title="Customer Stock Move to invoice" colSpan="12" field="customerStockMoveToInvoice" type="many-to-many" domain="self.statusSelect = 3 AND self.typeSelect = 2" target="com.axelor.apps.stock.db.StockMove" grid-view="stock-move-out-grid-mass" canNew="false" canEdit="false"/>
+	</form>
     
-    <form name="stock-move-multi-purchase-invoicing-form" model="com.axelor.apps.stock.db.StockMove" title="Mass Suppl. Stock Move Invoicing" >
-		<panel-related field="$supplierStockMoveToInvoice" title="Supplier Stock Move to invoice" colSpan="12" type="many-to-many" target="com.axelor.apps.stock.db.StockMove" domain="self.statusSelect = 3 AND self.typeSelect = 3" canNew="false" canEdit="false"/>
-		<panel sidebar="true" name="actions" title="Actions">
-			<button name="generateInvoiceConcatStockMove" title="Generate single invoice" onClick="action-validate-supplychain-incoming-stock-move-check-selection,action-supplychain-stock-move-method-generate-concat-invoice"/>
-			<button name="generateMultiInvoice" title="Generate one invoice per incoming stockMove" onClick="action-validate-supplychain-incoming-stock-move-check-selection,action-supplychain-stock-move-method-generate-multi-invoice"/>
-	  	</panel>
-    </form>
-    
+    <form name="stock-move-multi-purchase-invoicing-form" title="Mass Suppl. Stock Move Invoicing" model="com.axelor.apps.stock.db.StockMove" width="large">
+		<panel name="actions" title="Actions">
+			<button name="generateMultiInvoice" title="Generate one invoice per incoming stockMove" readonlyIf="!supplierStockMoveToInvoice || supplierStockMoveToInvoice.length &lt; 2" colSpan="6" onClick="action-validate-supplychain-incoming-stock-move-check-selection,action-supplychain-stock-move-method-generate-multi-invoice"/>
+		  	<button name="generateInvoiceConcatStockMove" title="Generate single invoice" readonlyIf="!supplierStockMoveToInvoice || supplierStockMoveToInvoice.length == 0" colSpan="6" onClick="action-validate-supplychain-incoming-stock-move-check-selection,action-supplychain-stock-move-method-generate-concat-invoice"/>
+		</panel>
+ 		<panel-related height="17" title="Supplier Stock Move to invoice" colSpan="12" field="supplierStockMoveToInvoice" type="many-to-many" domain="self.statusSelect = 3 AND self.typeSelect = 3" target="com.axelor.apps.stock.db.StockMove" canNew="false" canEdit="false" grid-view="stock-move-in-grid-mass"/>
+	</form>
+	
+	    
     <form name="stock-move-supplychain-concat-invoice-confirm-form" model="com.axelor.apps.stock.db.StockMove" title="Confirmation" onNew="action-record-load-dummy-field-generate-invoice">
 		<panel name="main" >
 			<field name="$paymentCondition" title="Payment condition" target="com.axelor.apps.account.db.PaymentCondition" colSpan="12" width="200px" widget="SuggestBox" showIf="paymentConditionToCheck"/>


### PR DESCRIPTION
Change dummy fields "$supplierStockMoveToInvoice" and
"$customerStockMoveToInvoice" to normal fields to allow javascript
evaluation on branch 4.1. See issue #7455