### PR TITLE
RM9780: Display associatedUser only when userType is "signatory",

### DIFF
--- a/axelor-bank-payment/src/main/resources/views/EbicsUser.xml
+++ b/axelor-bank-payment/src/main/resources/views/EbicsUser.xml
@@ -18,20 +18,19 @@
 		<field name="ebicsPartner.ebicsTypeSelect"/>
 		<field name="ebicsPartner.ebicsBank"/>
 		<field name="userTypeSelect"/>
-		<field name="associatedUser"/>
 		<field name="statusSelect"/>
 	</grid>
 	
 	<form name="ebics-user-form" title="Ebics user" model="com.axelor.apps.bankpayment.db.EbicsUser" onSave="save,action-ebics-user-method-generate-dn">
 		<panel title="General information" colSpan="12">
 			<field name="statusSelect" colSpan="12"/>
-			<field name="fullName" colSpan="12" readonly="true"/>
-			<field name="name" colSpan="6" onChange="action-ebics-user-record-set-fullname"/>
-			<field name="associatedUser" colSpan="6" canNew="false" canEdit="false" canView="false" onChange="action-ebics-user-record-set-fullname"/>
+			<field name="fullName" colSpan="12" hidden="true"/>
+			<field name="name" onChange="action-ebics-user-record-set-fullname"/>
 			<field name="password" requiredIf="ebicsPartner.ebicsTypeSelect == 0"/>
 			<field name="userId" help="Name of the user or service" x-bind="{{userId|uppercase}}" pattern='^[A-Z0-9]+$' readonlyIf="statusSelect &gt; 2"/>
 			<field name="securityMedium" readonlyIf="statusSelect == 3"/>
-			<field name="userTypeSelect" widget="RadioSelect" readonlyIf="statusSelect == 3"/>
+			<field name="userTypeSelect" widget="RadioSelect" readonlyIf="statusSelect == 3" onChange="action-ebics-user-record-set-fullname"/>
+			<field name="associatedUser" canNew="false" canEdit="false" canView="false" onChange="action-ebics-user-record-set-fullname" showIf="userTypeSelect == 1"/>
 			<field name="nextOrderId"/>
 			<field name="ebicsPartner" help="Subscription or contract to which the user is associated" readonlyIf="statusSelect &gt; 2"/>
 			<field name="ebicsPartner.ebicsTypeSelect" widget="RadioSelect"/>
@@ -91,7 +90,8 @@
 	</form>
 	
 	<action-record name="action-ebics-user-record-set-fullname" model="com.axelor.apps.bankpayment.db.EbicsUser">
-		<field name="fullName" expr="eval: (name ? name : '') + (associatedUser?.fullName ? ' - ' + associatedUser?.fullName : '')"/>
+		<field name="fullName" expr="eval: (name ? name : '')" if="eval: userTypeSelect == 0"/>
+		<field name="fullName" expr="eval: (name ? name : '') + (associatedUser?.fullName ? ' - ' + associatedUser?.fullName : '')" if="eval: userTypeSelect == 1"/>
 	</action-record>
 
 	<action-method name="action-ebics-user-method-generate-certificates">


### PR DESCRIPTION
remove associatedUser part of fullName when userType is "transport".