### PR TITLE
account: fix NPE on payer quality generation

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/web/AppAccountController.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/web/AppAccountController.java
@@ -21,31 +21,28 @@ package com.axelor.apps.account.web;
 import com.axelor.apps.account.service.app.AppAccountService;
 import com.axelor.apps.account.service.debtrecovery.PayerQualityService;
 import com.axelor.exception.service.TraceBackService;
+import com.axelor.inject.Beans;
 import com.axelor.rpc.ActionRequest;
 import com.axelor.rpc.ActionResponse;
 import com.google.inject.Inject;
 
 public class AppAccountController {
-
-	@Inject
-	private PayerQualityService payerQualityService;
-	
 	@Inject
 	private AppAccountService appAccountService;
 
 	public void payerQualityProcess(ActionRequest request, ActionResponse response)  {
 
 		try  {
-			payerQualityService.payerQualityProcess();
+			Beans.get(PayerQualityService.class).payerQualityProcess();
 		}
 		catch (Exception e) { TraceBackService.trace(response, e); }
 	}
-	
+
 	public void generateAccountConfigurations(ActionRequest request, ActionResponse response)  {
-		
+
 		appAccountService.generateAccountConfigurations();
-		
+
 		response.setReload(true);
-		
+
 	}
 }

--- a/axelor-account/src/main/java/com/axelor/apps/account/web/AppAccountController.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/web/AppAccountController.java
@@ -24,11 +24,11 @@ import com.axelor.exception.service.TraceBackService;
 import com.axelor.rpc.ActionRequest;
 import com.axelor.rpc.ActionResponse;
 import com.google.inject.Inject;
-import com.google.inject.Injector;
 
 public class AppAccountController {
 
-	private Injector injector;
+	@Inject
+	private PayerQualityService payerQualityService;
 	
 	@Inject
 	private AppAccountService appAccountService;
@@ -36,8 +36,7 @@ public class AppAccountController {
 	public void payerQualityProcess(ActionRequest request, ActionResponse response)  {
 
 		try  {
-			PayerQualityService pqs = injector.getInstance(PayerQualityService.class);
-			pqs.payerQualityProcess();
+			payerQualityService.payerQualityProcess();
 		}
 		catch (Exception e) { TraceBackService.trace(response, e); }
 	}


### PR DESCRIPTION
This should fix an NPE when clicking on “Compute payers quality” in app account configuration