### PR TITLE
AccountingReport: Clarify the meaning of date_val

### DIFF
--- a/axelor-account/src/main/resources/domains/AccountingReport.xml
+++ b/axelor-account/src/main/resources/domains/AccountingReport.xml
@@ -17,7 +17,7 @@
     <integer name="typeSelect" title="Printing output"  required="true"/>
     <many-to-many name="partnerSet" ref="com.axelor.apps.base.db.Partner" title="Partners"/>
     <many-to-one name="year" ref="com.axelor.apps.base.db.Year" title="Fiscal year"/>
-    <date name="date" column="date_val" title="Creation Date" required="true"/>
+    <date name="date" column="date_val" title="Closing Date" required="true"/>
     <datetime name="publicationDateTime" title="Last print date" tz="true" readonly="true"/>
     <boolean name="global" title="Global" default="false"/>
     <boolean name="globalByPartner" title="Subtotal by partner" default="false"/>

--- a/axelor-account/src/main/resources/i18n/messages.csv
+++ b/axelor-account/src/main/resources/i18n/messages.csv
@@ -1592,3 +1592,4 @@
 "value:Accounting",,,
 "value:Budget",,,
 "value:Invoicing",,,
+"Closing Date",,,

--- a/axelor-account/src/main/resources/i18n/messages_en.csv
+++ b/axelor-account/src/main/resources/i18n/messages_en.csv
@@ -1592,3 +1592,4 @@
 "value:Accounting",,,
 "value:Budget",,,
 "value:Invoicing",,,
+"Closing Date",,,

--- a/axelor-account/src/main/resources/i18n/messages_fr.csv
+++ b/axelor-account/src/main/resources/i18n/messages_fr.csv
@@ -1592,3 +1592,4 @@
 "value:Accounting","Comptabilité",,
 "value:Budget","Budget",,
 "value:Invoicing","Facturation",,
+"Closing date","Date d'arrêté",,


### PR DESCRIPTION
Maybe it's just me, but it seems that "Creation date" doesn't bring to the attention of the user that the report won't take into account any information after the filled in date.
Renaming to closing date seems more intuitive.