### PR TITLE
bank-payment: always run xjc after generateCode

### DIFF
--- a/axelor-bank-payment/build.gradle
+++ b/axelor-bank-payment/build.gradle
@@ -51,3 +51,4 @@ task xjc () {
 }
 
 compileJava.dependsOn xjc
+generateCode.finalizedBy xjc


### PR DESCRIPTION
This fix an issue where you've to manually run xjc (or anything
triggering it) to actually have all needed sources (this makes eclipse
target working out of the box).