### PR TITLE
bank-payment: add explicit dependency on apache santuario

### DIFF
--- a/axelor-bank-payment/build.gradle
+++ b/axelor-bank-payment/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
 	compile files("src/main/lib/ebics-1.0.2.jar")
 	compile "org.bouncycastle:bcprov-jdk15:1.46"
+	compile "org.apache.santuario:xmlsec:1.4.3"
 }
 
 license {


### PR DESCRIPTION
It seems that the dependency used to be pulled by another mean but this
is not the case anymore.
This fix a build failure because of classes from
org.apache.xml.security.* not being found.