### PR TITLE
user: hide contact info pane if new

### DIFF
--- a/axelor-base/src/main/resources/views/User.xml
+++ b/axelor-base/src/main/resources/views/User.xml
@@ -25,7 +25,7 @@
 		</panel>
         <panel-include view="user-form" from="axelor-core"/>
         <panel-tabs>
-			 <panel name="contactInformations" title="Contact Informations">
+		<panel name="contactInformations" title="Contact Informations" showIf="id != null">
       			<button name="partner" title="Create Partner" colSpan="12" showIf="partner == null &amp;&amp; id != null &amp;&amp; id>0" onClick="action-user-record-form-partner-contact"/>
       			<field name="partner" showTitle="false" colSpan="12" canNew="true" domain="self.partnerTypeSelect = 2 OR self.isContact = true OR self.isEmployee = true" form-view="partner-employee-form" grid-view="partner-employee-grid">
         			<editor x-viewer="true">


### PR DESCRIPTION
This fixes a "Name cannot be null" error when attempting to fill details upon creation