### PR TITLE
PrintingSettings: remove languageSelect from view

### DIFF
--- a/axelor-base/src/main/resources/views/PrintingSetting.xml
+++ b/axelor-base/src/main/resources/views/PrintingSetting.xml
@@ -6,7 +6,6 @@
 	<form name="printing-setting-form" title="Printing Setting" model="com.axelor.apps.base.db.PrintingSettings" width="large">
 		<panel name="main" >
 			<field name="name"/>
-			<field name="languageSelect"/>
 			<field name="defaultMailBirtTemplate" form-view="birt-template-form" grid-view="birt-template-grid" />
 			<field name="logoPositionSelect" />
 			<field name="colorCode" />
@@ -14,8 +13,8 @@
 				<field name="pdfHeader" colSpan="12" widget="html" showTitle="false"/>
 			</panel>
 			<panel name="companyFooter" title="Company Footer" colSpan="12">
-	       		<field name="pdfFooter" colSpan="12" widget="html" showTitle="false"/>
-	       	</panel>
+				<field name="pdfFooter" colSpan="12" widget="html" showTitle="false"/>
+			</panel>
        	</panel>
     </form>
     


### PR DESCRIPTION
Language select has been removed in commit f02cd3f4e96c7d091dc9efbce9a580daab00ad83 in order to use the language defined on partner or user level. It was left on the view.