### PR TITLE
Fix StockMove cancellation

### DIFF
--- a/axelor-stock/src/main/resources/views/StockMove.xml
+++ b/axelor-stock/src/main/resources/views/StockMove.xml
@@ -522,7 +522,7 @@
 		<view-param name="popup-save" value="false"/>
 		<view-param name="forceEdit" value="true" />
 		<context name="_showRecord" expr="eval: __this__.id" />
-		<context name="_xApplicationType" expr="eval: __this__.getClass().getCanonicalName()"/>
+		<context name="_xApplicationType" expr="eval: __this__.getClass().getCanonicalName().replaceAll('[$].*$', '')"/>
 	</action-view>
 
 	<form name="stock-move-cancel-wizard-form" model="com.axelor.apps.stock.db.StockMove" title="Cancellation confirmation" >


### PR DESCRIPTION
Stock move were not cancellable because of wrong filtering on cancel reasons due to class name mangling.