### PR TITLE
partner: accounting situations on save

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/PartnerAccountRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/PartnerAccountRepository.java
@@ -40,7 +40,7 @@ public class PartnerAccountRepository extends PartnerBaseRepository {
 		try {
 
 			if(partner.getId() == null){
-				return super.save(partner);
+				partner = super.save(partner);
 			}
 			if(!partner.getIsContact() && appService.isApp("account")){
 				List<AccountingSituation> accountingSituationList = Beans.get(AccountingSituationService.class).createAccountingSituation(Beans.get(PartnerRepository.class).find(partner.getId()));


### PR DESCRIPTION
Remove the need to save partner twice in order to have its accounting situations populated