### PR TITLE
accounting: correctly fallback to global params if partner is empty

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/AccountCustomerService.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/AccountCustomerService.java
@@ -17,6 +17,18 @@
  */
 package com.axelor.apps.account.service;
 
+import java.lang.invoke.MethodHandles;
+import java.math.BigDecimal;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.List;
+
+import javax.persistence.Query;
+import javax.persistence.TemporalType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.axelor.apps.account.db.Account;
 import com.axelor.apps.account.db.AccountConfig;
 import com.axelor.apps.account.db.AccountingSituation;
@@ -25,7 +37,6 @@ import com.axelor.apps.account.db.repo.AccountingSituationRepository;
 import com.axelor.apps.account.db.repo.MoveLineRepository;
 import com.axelor.apps.account.db.repo.MoveRepository;
 import com.axelor.apps.account.exception.IExceptionMessage;
-import com.axelor.apps.account.service.config.AccountConfigService;
 import com.axelor.apps.base.db.Company;
 import com.axelor.apps.base.db.Partner;
 import com.axelor.apps.base.service.app.AppBaseService;
@@ -37,16 +48,6 @@ import com.axelor.i18n.I18n;
 import com.axelor.inject.Beans;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.persistence.Query;
-import javax.persistence.TemporalType;
-import java.lang.invoke.MethodHandles;
-import java.math.BigDecimal;
-import java.time.ZoneOffset;
-import java.util.Date;
-import java.util.List;
 
 public class AccountCustomerService {
 
@@ -310,64 +311,36 @@ public class AccountCustomerService {
 		}
 		accountingSituation.setCustAccountMustBeUpdateOk(false);
 		accSituationRepo.save(accountingSituation);
-		
+
 		return accountingSituation;
 	}
 
 
 
 	public Account getPartnerAccount(Partner partner, Company company, boolean isSupplierInvoice) throws AxelorException  {
-
-		if(isSupplierInvoice)  {  return this.getSupplierAccount(partner, company);  }
-
-		else  {  return this.getCustomerAccount(partner, company);  }
-
+		return isSupplierInvoice ? getSupplierAccount(partner, company) : getCustomerAccount(partner, company);
 	}
 
 
 	protected Account getCustomerAccount(Partner partner, Company company) throws AxelorException  {
-
-		Account customerAccount = null;
-		AccountingSituation accountingSituation = accountingSituationService.getAccountingSituation(partner, company);
-
-		if(accountingSituation != null)   {
-			customerAccount = accountingSituation.getCustomerAccount();
-		}
-
-		if(customerAccount == null)  {
-			AccountConfigService accountConfigService = new AccountConfigService();
-			customerAccount = accountConfigService.getCustomerAccount(accountConfigService.getAccountConfig(company));
-		}
+		Account customerAccount = accountingSituationService.getCustomerAccount(partner, company);
 
 		if (customerAccount == null) {
 			throw new AxelorException(partner, IException.MISSING_FIELD, I18n.get(IExceptionMessage.ACCOUNT_CUSTOMER_1), AppBaseServiceImpl.EXCEPTION, company.getName());
 		}
 
 		return customerAccount;
-
 	}
 
 
 	protected Account getSupplierAccount(Partner partner, Company company) throws AxelorException  {
-
-		Account supplierAccount = null;
-		AccountingSituation accountingSituation = accountingSituationService.getAccountingSituation(partner, company);
-
-		if (accountingSituation != null) {
-			supplierAccount = accountingSituation.getSupplierAccount();
-		}
-
-		if(supplierAccount == null)  {
-			AccountConfigService accountConfigService = new AccountConfigService();
-			supplierAccount = accountConfigService.getSupplierAccount(accountConfigService.getAccountConfig(company));
-		}
+		Account supplierAccount = accountingSituationService.getSupplierAccount(partner, company);
 
 		if (supplierAccount == null) {
 			throw new AxelorException(partner, IException.MISSING_FIELD, I18n.get(IExceptionMessage.ACCOUNT_CUSTOMER_2), AppBaseServiceImpl.EXCEPTION, company.getName());
 		}
 
 		return supplierAccount;
-
 	}
 
 }

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/workflow/ventilate/VentilateState.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/workflow/ventilate/VentilateState.java
@@ -19,24 +19,21 @@ package com.axelor.apps.account.service.invoice.workflow.ventilate;
 
 import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
-import java.util.List;
-
 import java.time.LocalDate;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.axelor.inject.Beans;
-import com.axelor.apps.account.service.AccountingSituationService;
-import com.axelor.apps.account.service.JournalService;
-import com.axelor.apps.account.db.repo.InvoiceRepository;
-import com.axelor.apps.account.exception.IExceptionMessage;
-import com.axelor.apps.account.service.app.AppAccountService;
 
 import com.axelor.apps.account.db.Account;
 import com.axelor.apps.account.db.AccountConfig;
-import com.axelor.apps.account.db.AccountingSituation;
 import com.axelor.apps.account.db.Invoice;
 import com.axelor.apps.account.db.Move;
+import com.axelor.apps.account.db.repo.InvoiceRepository;
+import com.axelor.apps.account.exception.IExceptionMessage;
+import com.axelor.apps.account.service.AccountingSituationService;
+import com.axelor.apps.account.service.JournalService;
+import com.axelor.apps.account.service.app.AppAccountService;
 import com.axelor.apps.account.service.config.AccountConfigService;
 import com.axelor.apps.account.service.invoice.InvoiceToolService;
 import com.axelor.apps.account.service.invoice.workflow.WorkflowInvoice;
@@ -46,6 +43,7 @@ import com.axelor.apps.base.service.administration.SequenceService;
 import com.axelor.exception.AxelorException;
 import com.axelor.exception.db.IException;
 import com.axelor.i18n.I18n;
+import com.axelor.inject.Beans;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
@@ -53,7 +51,7 @@ import com.google.inject.servlet.RequestScoped;
 
 @RequestScoped
 public class VentilateState extends WorkflowInvoice {
-	
+
 	private final Logger log = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
 	protected SequenceService sequenceService;
@@ -118,13 +116,12 @@ public class VentilateState extends WorkflowInvoice {
 	}
 
 	protected void setPartnerAccount() throws AxelorException {
-		AccountingSituation accountSituation = Beans.get(AccountingSituationService.class).getAccountingSituation(invoice.getPartner(), invoice.getCompany());
-		if(accountSituation == null)  {
-			accountSituation = Beans.get(AccountingSituationService.class).createAccountingSituation(invoice.getPartner(), invoice.getCompany());
-		}
 
 		if(invoice.getPartnerAccount() == null)  {
-			Account account = InvoiceToolService.isPurchase(invoice) ? accountSituation.getSupplierAccount() : accountSituation.getCustomerAccount();
+			AccountingSituationService situationService = Beans.get(AccountingSituationService.class);
+			Account account = InvoiceToolService.isPurchase(invoice) ?
+					situationService.getSupplierAccount(invoice.getPartner(), invoice.getCompany()) :
+						situationService.getCustomerAccount(invoice.getPartner(), invoice.getCompany());
 
 			if (account == null) {
 				throw new AxelorException(IException.CONFIGURATION_ERROR, I18n.get(IExceptionMessage.VENTILATE_STATE_5));

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveToolService.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveToolService.java
@@ -27,14 +27,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.axelor.apps.account.db.Account;
-import com.axelor.apps.account.db.AccountConfig;
-import com.axelor.apps.account.db.AccountingSituation;
 import com.axelor.apps.account.db.Invoice;
 import com.axelor.apps.account.db.MoveLine;
 import com.axelor.apps.account.db.repo.InvoiceRepository;
 import com.axelor.apps.account.db.repo.MoveLineRepository;
 import com.axelor.apps.account.exception.IExceptionMessage;
 import com.axelor.apps.account.service.AccountCustomerService;
+import com.axelor.apps.account.service.AccountingSituationService;
 import com.axelor.apps.account.service.config.AccountConfigService;
 import com.axelor.apps.base.db.Company;
 import com.axelor.apps.base.db.Partner;
@@ -55,7 +54,7 @@ public class MoveToolService {
 	protected AccountConfigService accountConfigService;
 
 	@Inject
-	public MoveToolService(MoveLineService moveLineService, MoveLineRepository moveLineRepository, 
+	public MoveToolService(MoveLineService moveLineService, MoveLineRepository moveLineRepository,
 			AccountCustomerService accountCustomerService, AccountConfigService accountConfigService) {
 
 		this.moveLineService = moveLineService;
@@ -221,28 +220,8 @@ public class MoveToolService {
 
 
 	public Account getCustomerAccount(Partner partner, Company company, boolean isSupplierAccount) throws AxelorException  {
-
-		AccountingSituation accountingSituation = accountCustomerService.getAccountingSituationService().getAccountingSituation(partner, company);
-
-		if(accountingSituation != null)  {
-
-			if(!isSupplierAccount && accountingSituation.getCustomerAccount() != null )  {
-				return accountingSituation.getCustomerAccount();
-			}
-			else if(isSupplierAccount && accountingSituation.getSupplierAccount() != null)  {
-				return accountingSituation.getSupplierAccount();
-			}
-		}
-
-		AccountConfig accountConfig = accountConfigService.getAccountConfig(company);
-
-		if(isSupplierAccount)  {
-			return accountConfigService.getSupplierAccount(accountConfig);
-		}
-		else  {
-			return accountConfigService.getCustomerAccount(accountConfig);
-		}
-
+		AccountingSituationService situationService = Beans.get(AccountingSituationService.class);
+		return isSupplierAccount ? situationService.getSupplierAccount(partner, company) : situationService.getCustomerAccount(partner, company);
 	}
 
 
@@ -365,31 +344,31 @@ public class MoveToolService {
 		return null;
 	}
 
-	
+
 	public List <MoveLine> orderListByDate(List <MoveLine> list)  {
 		Collections.sort(list, new Comparator<MoveLine>() {
 
 			@Override
 			public int compare(MoveLine o1, MoveLine o2) {
-				
+
 				return o1.getDate().compareTo(o2.getDate());
 			}
 		});
 
 		return list;
 	}
-	
-	
+
+
 	public boolean isDebitMoveLine(MoveLine moveLine)  {
-		
+
 		if(moveLine.getDebit().compareTo(BigDecimal.ZERO) == 1)  {
 			return true;
 		}
 		else  {
 			return false;
 		}
-		
+
 	}
-	
-		
+
+
 }

--- a/axelor-human-resource/src/main/java/com/axelor/apps/hr/service/expense/ExpenseServiceImpl.java
+++ b/axelor-human-resource/src/main/java/com/axelor/apps/hr/service/expense/ExpenseServiceImpl.java
@@ -31,13 +31,11 @@ import java.util.Set;
 
 import javax.mail.MessagingException;
 
-import com.axelor.apps.hr.db.repo.ExpenseLineRepository;
 import org.apache.commons.codec.binary.Base64;
 
 import com.axelor.apps.account.db.Account;
 import com.axelor.apps.account.db.AccountConfig;
 import com.axelor.apps.account.db.AccountManagement;
-import com.axelor.apps.account.db.AccountingSituation;
 import com.axelor.apps.account.db.AnalyticAccount;
 import com.axelor.apps.account.db.AnalyticMoveLine;
 import com.axelor.apps.account.db.Invoice;
@@ -73,6 +71,7 @@ import com.axelor.apps.hr.db.Expense;
 import com.axelor.apps.hr.db.ExpenseLine;
 import com.axelor.apps.hr.db.HRConfig;
 import com.axelor.apps.hr.db.KilometricAllowParam;
+import com.axelor.apps.hr.db.repo.ExpenseLineRepository;
 import com.axelor.apps.hr.db.repo.ExpenseRepository;
 import com.axelor.apps.hr.exception.IExceptionMessage;
 import com.axelor.apps.hr.service.EmployeeAdvanceService;
@@ -128,6 +127,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 
 	}
 
+	@Override
 	public ExpenseLine computeAnalyticDistribution(ExpenseLine expenseLine) throws AxelorException{
 
 		if(appAccountService.getAppAccount().getAnalyticDistributionTypeSelect() == AppAccountRepository.DISTRIBUTION_TYPE_FREE)  {
@@ -159,6 +159,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 
 	}
 
+	@Override
 	public ExpenseLine createAnalyticDistributionWithTemplate(ExpenseLine expenseLine) throws AxelorException {
 		List<AnalyticMoveLine> analyticMoveLineList = null;
 		analyticMoveLineList = analyticMoveLineService.generateLinesWithTemplate(expenseLine.getAnalyticDistributionTemplate(), expenseLine.getUntaxedAmount());
@@ -172,6 +173,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 	}
 
 
+	@Override
 	public Expense compute(Expense expense) {
 
 		BigDecimal exTaxTotal = BigDecimal.ZERO;
@@ -195,7 +197,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 				if (kilometricExpenseLine.getTotalTax() != null) {
 					taxTotal = taxTotal.add(kilometricExpenseLine.getTotalTax());
 				}
-				if (kilometricExpenseLine.getTotalAmount() != null) { 
+				if (kilometricExpenseLine.getTotalAmount() != null) {
 					inTaxTotal = inTaxTotal.add(kilometricExpenseLine.getTotalAmount());
 				}
 			}
@@ -206,6 +208,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 		return expense;
 	}
 
+	@Override
 	@Transactional(rollbackOn = {AxelorException.class, Exception.class})
 	public void confirm(Expense expense) throws AxelorException {
 
@@ -216,6 +219,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 	}
 
 
+	@Override
 	public Message sendConfirmationEmail(Expense expense) throws AxelorException, ClassNotFoundException, InstantiationException, IllegalAccessException, MessagingException, IOException {
 
 		HRConfig hrConfig = hrConfigService.getHRConfig(expense.getCompany());
@@ -231,6 +235,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 	}
 
 
+	@Override
 	@Transactional(rollbackOn = {AxelorException.class, Exception.class})
 	public void validate(Expense expense) throws AxelorException {
 
@@ -265,6 +270,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 	}
 
 
+	@Override
 	public Message sendValidationEmail(Expense expense) throws AxelorException, ClassNotFoundException, InstantiationException, IllegalAccessException, MessagingException, IOException {
 
 		HRConfig hrConfig = hrConfigService.getHRConfig(expense.getCompany());
@@ -279,6 +285,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 
 	}
 
+	@Override
 	@Transactional(rollbackOn = {AxelorException.class, Exception.class})
 	public void refuse(Expense expense) throws AxelorException {
 
@@ -289,6 +296,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 
 	}
 
+	@Override
 	public Message sendRefusalEmail(Expense expense) throws AxelorException, ClassNotFoundException, InstantiationException, IllegalAccessException, MessagingException, IOException {
 
 		HRConfig hrConfig = hrConfigService.getHRConfig(expense.getCompany());
@@ -304,6 +312,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 	}
 
 
+	@Override
 	@Transactional(rollbackOn = {AxelorException.class, Exception.class})
 	public Move ventilate(Expense expense) throws AxelorException {
 
@@ -343,14 +352,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 
 		int moveLineId = 1;
 		int expenseLineId = 1;
-		AccountingSituation accSituation =  accountingSituationService.getAccountingSituation(expense.getUser().getPartner(), expense.getCompany());
-		Account employeeAccount = null;
-		if (accSituation != null) {
-			employeeAccount = accSituation.getEmployeeAccount();
-		}
-		if (employeeAccount == null) {
-			employeeAccount = accountConfigService.getExpenseEmployeeAccount(accountConfig);
-		}
+		Account employeeAccount = accountingSituationService.getEmployeeAccount(expense.getUser().getPartner(), expense.getCompany());
 		moveLines.add(moveLineService.createMoveLine(move, expense.getUser().getPartner(), employeeAccount, expense.getInTaxTotal(), false, moveDate, moveDate, moveLineId++, ""));
 
 		for (ExpenseLine expenseLine : getExpenseLineList(expense)) {
@@ -397,6 +399,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 		return move;
 	}
 
+	@Override
 	@Transactional(rollbackOn = {AxelorException.class, Exception.class})
 	public void cancel(Expense expense) throws AxelorException {
 		Move move = expense.getMove();
@@ -418,6 +421,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 		expenseRepository.save(expense);
 	}
 
+	@Override
 	public Message sendCancellationEmail(Expense expense) throws AxelorException, ClassNotFoundException, InstantiationException, IllegalAccessException, MessagingException, IOException {
 
 		HRConfig hrConfig = hrConfigService.getHRConfig(expense.getCompany());
@@ -432,6 +436,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 
 	}
 
+	@Override
 	@Transactional(rollbackOn = { AxelorException.class, Exception.class })
 	public void addPayment(Expense expense, BankDetails bankDetails) throws AxelorException {
 
@@ -465,11 +470,13 @@ public class ExpenseServiceImpl implements ExpenseService {
 				.subtract(expense.getWithdrawnCash()).subtract(expense.getPersonalExpenseAmount()));
 	}
 
+	@Override
 	public void addPayment(Expense expense) throws AxelorException {
 		addPayment(expense, expense.getCompany().getDefaultBankDetails());
 	}
 
-    @Transactional(rollbackOn = {AxelorException.class, Exception.class})
+    @Override
+	@Transactional(rollbackOn = {AxelorException.class, Exception.class})
     public void cancelPayment(Expense expense) throws AxelorException {
         BankOrder bankOrder = expense.getBankOrder();
 
@@ -487,6 +494,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 		expenseRepository.save(expense);
     }
 
+	@Override
 	public List<InvoiceLine> createInvoiceLines(Invoice invoice, List<ExpenseLine> expenseLineList, int priority) throws AxelorException {
 
 		List<InvoiceLine> invoiceLineList = new ArrayList<>();
@@ -503,6 +511,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 
 	}
 
+	@Override
 	public List<InvoiceLine> createInvoiceLine(Invoice invoice, ExpenseLine expenseLine, int priority) throws AxelorException {
 
 		Product product = expenseLine.getExpenseProduct();
@@ -545,6 +554,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 		return invoiceLineGenerator.creates();
 	}
 
+	@Override
 	public void getExpensesTypes(ActionRequest request, ActionResponse response) {
 		List<Map<String, String>> dataList = new ArrayList<>();
 		try {
@@ -564,6 +574,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 		}
 	}
 
+	@Override
 	@Transactional
 	public void insertExpenseLine(ActionRequest request, ActionResponse response) {
 		User user = AuthUtils.getUser();
@@ -589,7 +600,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 			expense.addGeneralExpenseLineListItem(expenseLine);
 
 			Beans.get(ExpenseRepository.class).save(expense);
-			HashMap<String, Object> data = new HashMap<String, Object>();
+			HashMap<String, Object> data = new HashMap<>();
 			data.put("id", expenseLine.getId());
 			response.setData(data);
 			response.setTotal(1);
@@ -618,6 +629,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 		return expense;
 	}
 
+	@Override
 	public BigDecimal computePersonalExpenseAmount(Expense expense) {
 
 		BigDecimal personalExpenseAmount = new BigDecimal("0.00");
@@ -631,6 +643,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 	}
 
 
+	@Override
 	public BigDecimal computeAdvanceAmount(Expense expense) {
 
 		BigDecimal advanceAmount = new BigDecimal("0.00");
@@ -644,6 +657,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 		return advanceAmount;
 	}
 
+	@Override
 	public Product getKilometricExpenseProduct(Expense expense) throws AxelorException {
 
 		HRConfig hrConfig = hrConfigService.getHRConfig(expense.getCompany());
@@ -653,6 +667,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 	}
 
 
+	@Override
 	public void setDraftSequence(Expense expense) throws AxelorException {
 		if (expense.getId() != null && Strings.isNullOrEmpty(expense.getExpenseSeq())) {
 			expense.setExpenseSeq(Beans.get(SequenceService.class).getDraftSequenceNumber(expense));
@@ -666,7 +681,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 
     HRConfig hrConfig = hrConfigService.getHRConfig(expense.getCompany());
 		Sequence sequence = hrConfigService.getExpenseSequence(hrConfig);
-  
+
 		if (sequence != null) {expense.setExpenseSeq(Beans.get(SequenceService.class).getSequenceNumber(sequence, expense.getSentDate()));if (expense.getExpenseSeq() != null) {
 				return;
 			}
@@ -677,24 +692,24 @@ public class ExpenseServiceImpl implements ExpenseService {
 
 	@Override
 	public List<KilometricAllowParam> getListOfKilometricAllowParamVehicleFilter(ExpenseLine expenseLine) throws AxelorException {
-		
+
 		List<KilometricAllowParam> kilometricAllowParamList = new ArrayList<>();
-		
+
 		Expense expense = expenseLine.getExpense();
-		
+
 		if (expense == null) {
 			return kilometricAllowParamList;
 		}
-		
+
 		if (expense.getId() != null) {
 			expense = expenseRepository.find(expense.getId());
 		}
-		
+
 		LocalDate expenseDate = expenseLine.getExpenseDate();
 		if (expense.getUser() == null || expense.getUser().getEmployee() == null || expenseDate == null) {
 			return kilometricAllowParamList;
 		}
-		
+
 		List<EmployeeVehicle> vehicleList = expense.getUser().getEmployee().getEmployeeVehicleList();
 
 
@@ -715,10 +730,11 @@ public class ExpenseServiceImpl implements ExpenseService {
 				kilometricAllowParamList.add(vehicle.getKilometricAllowParam());
 			}
 		}
-		
+
 		return kilometricAllowParamList;
 	}
 
+	@Override
 	public List<ExpenseLine> getExpenseLineList(Expense expense) {
 		List<ExpenseLine> expenseLineList = new ArrayList<>();
 		if (expense.getGeneralExpenseLineList() != null) {
@@ -729,6 +745,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 		}
 		return expenseLineList;
 	}
+	@Override
 	public void completeExpenseLines(Expense expense) {
 		ExpenseLineRepository expenseLineRepository = Beans.get(ExpenseLineRepository.class);
 		List<ExpenseLine> expenseLineList = expenseLineRepository.all().filter("self.expense.id = :_expenseId")


### PR DESCRIPTION
AccountingSituation::get{Customer,Supplier,Employee}Account should never
be used directly except in AccountingSituationService, in order to
correctly fallback to accounts defined on company level if there's no
account defined on specific partner.