### PR TITLE
Revert "Product unit cannot be set"

### DIFF
--- a/axelor-base/src/main/resources/views/Product.xml
+++ b/axelor-base/src/main/resources/views/Product.xml
@@ -101,7 +101,7 @@
                         onChange="action-product-validate-sale-supply-select"
                         hideIf="isShippingCostsProduct"/>
 					<panel name="units" title="Units" colSpan="6">
-						<field name="unit" canEdit="false" colSpan="12" form-view="unit-form" grid-view="unit-grid" readonlyIf="productTypeSelect != 'storable'"/>
+						<field name="unit" canEdit="false" colSpan="12" form-view="unit-form" grid-view="unit-grid" readonlyIf="productTypeSelect = 'storable'"/>
 						<field name="salesUnit" canEdit="false" hideIf="!sellable" colSpan="12" form-view="unit-form" grid-view="unit-grid" if="__config__.app.getApp('sale').getManageSalesUnits()"/>
 						<field name="purchasesUnit" canEdit="false" hideIf="!purchasable" colSpan="12" form-view="unit-form" grid-view="unit-grid" if="__config__.app.getApp('purchase').getManagePurchasesUnits()"/>
 					</panel>


### PR DESCRIPTION
Reverts axelor/axelor-business-suite#1607

The issue is more complex. The goal is to put in readonly the stock unit of a product if there is already a stock quantity in a stock location. Currently this readonly attribute doesn't appears because readonlyIf condition is wrong.

We can have a unit for service product. The standard behavior is to have only one unit (used for stocks, sales, purchases, project...). In option we can enable sales unit and purchase unit.

The unit should be copied on stock location line when creating it and if we update unit on product, we have to compare and convert (with button to propagate on stock location) and when we do a stock move we have to use the latest product unit and convert when we update stock location.

This feature will be done on the next version (V5.0.1?) because we have to release the wip branch soon.

For now, we can just remove the readonlyIf attribute.