### PR TITLE
sales: don't use Exception on workflow method

### DIFF
--- a/axelor-production/src/main/java/com/axelor/apps/production/service/SaleOrderWorkflowServiceProductionImpl.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/service/SaleOrderWorkflowServiceProductionImpl.java
@@ -34,36 +34,35 @@ import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
 public class SaleOrderWorkflowServiceProductionImpl extends SaleOrderWorkflowServiceSupplychainImpl {
-	
+
 	protected ProductionOrderSaleOrderService productionOrderSaleOrderService;
 	protected AppProductionService appProductionService;
-	
+
 	@Inject
-	public SaleOrderWorkflowServiceProductionImpl(SequenceService sequenceService, PartnerRepository partnerRepo, 
+	public SaleOrderWorkflowServiceProductionImpl(SequenceService sequenceService, PartnerRepository partnerRepo,
 			SaleOrderRepository saleOrderRepo, AppSaleService appSaleService, UserService userService,
-			SaleOrderStockService saleOrderStockService, SaleOrderPurchaseService saleOrderPurchaseService, 
+			SaleOrderStockService saleOrderStockService, SaleOrderPurchaseService saleOrderPurchaseService,
 			AppSupplychainService appSupplychainService, AccountingSituationSupplychainService accountingSituationSupplychainService,
 			ProductionOrderSaleOrderService productionOrderSaleOrderService, AppProductionService appProductionService) {
-		
+
 		super(sequenceService, partnerRepo, saleOrderRepo, appSaleService, userService,
 				saleOrderStockService, saleOrderPurchaseService, appSupplychainService, accountingSituationSupplychainService);
 
 		this.productionOrderSaleOrderService = productionOrderSaleOrderService;
 		this.appProductionService = appProductionService;
-		
-	}
-	
-	
-	@Override
-	@Transactional(rollbackOn = {AxelorException.class, Exception.class})
-	public void confirmSaleOrder(SaleOrder saleOrder) throws Exception  {
 
+	}
+
+
+	@Override
+	@Transactional(rollbackOn = {AxelorException.class, RuntimeException.class})
+	public void confirmSaleOrder(SaleOrder saleOrder) throws AxelorException  {
 		super.confirmSaleOrder(saleOrder);
-		
+
 		if(appProductionService.getAppProduction().getProductionOrderGenerationAuto())  {
 			productionOrderSaleOrderService.generateProductionOrder(saleOrder);
 		}
-		
+
 	}
-	
+
 }

--- a/axelor-sale/src/main/java/com/axelor/apps/sale/service/saleorder/SaleOrderWorkflowService.java
+++ b/axelor-sale/src/main/java/com/axelor/apps/sale/service/saleorder/SaleOrderWorkflowService.java
@@ -26,7 +26,6 @@ import com.google.inject.persist.Transactional;
 
 public interface SaleOrderWorkflowService {
 
-
 	@Transactional(rollbackOn = {AxelorException.class, Exception.class})
 	public Partner validateCustomer(SaleOrder saleOrder);
 
@@ -36,14 +35,12 @@ public interface SaleOrderWorkflowService {
 
 	public void cancelSaleOrder(SaleOrder saleOrder, CancelReason cancelReason, String cancelReasonStr);
 
-	public void finalizeSaleOrder(SaleOrder saleOrder) throws Exception;
+	public void finalizeSaleOrder(SaleOrder saleOrder) throws AxelorException;
 
-	public void confirmSaleOrder(SaleOrder saleOrder) throws Exception;
+	public void confirmSaleOrder(SaleOrder saleOrder) throws AxelorException;
 
 	public void saveSaleOrderPDFAsAttachment(SaleOrder saleOrder) throws AxelorException;
-	
+
 	public String getFileName(SaleOrder saleOrder);
-
-
 
 }


### PR DESCRIPTION
Remove throws Exception as it is actually never used, only AxelorException is thrown. Avoid
having a too wide throws declaration to leverage calling code structure (needed for axelor/axelor-addons#7)