### PR TITLE
product: improve fullname readability

### DIFF
--- a/axelor-base/src/main/java/com/axelor/apps/base/db/repo/ProductBaseRepository.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/db/repo/ProductBaseRepository.java
@@ -46,7 +46,7 @@ public class ProductBaseRepository extends ProductRepository{
 	@Override
 	public Product save(Product product){
 		
-		product.setFullName("["+product.getCode()+"]"+product.getName());
+		product.setFullName("["+product.getCode()+"] "+product.getName());
 		
 		product = super.save(product);
 		if(product.getBarCode() == null && product.getSerialNumber()!=null  &&  appBaseService.getAppBase().getActivateBarCodeGeneration() && product.getBarcodeTypeConfig()!=null) {


### PR DESCRIPTION
Add an unbreakable space after closing square bracket in product's fullname to improve readablity