### PR TITLE
invoices: replace hardcoded invoice.law by client box option

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/report/ITranslation.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/report/ITranslation.java
@@ -50,7 +50,6 @@ public interface ITranslation {
 	public static final String INVOICE_INVOICE_BALANCE_NO = /*$$(*/ "Invoice.invoiceBalanceNo"; /*)*/
 	public static final String INVOICE_DRAFT_INVOICE_NO = /*$$(*/ "Invoice.draftInvoiceNo"; /*)*/
 	public static final String INVOICE_REFUND_NO = /*$$(*/ "Invoice.refundNo"; /*)*/
-	public static final String INVOICE_LAW = /*$$(*/ "Invoice.law"; /*)*/
 	public static final String INVOICE_DISCOUNT_AMOUNT = /*$$(*/ "Invoice.discountAmount"; /*)*/
 	public static final String INVOICE_ADVANCE_PAYMENT = /*$$(*/ "Invoice.advancePayment"; /*)*/
 	public static final String INVOICE_OF = /*$$(*/ "Invoice.of"; /*)*/
@@ -60,22 +59,22 @@ public interface ITranslation {
 
 	public static final String INVOICE_TIMESHEET_TITLE = /*$$(*/ "Invoice.timesheetTitle"; /*)*/
 	public static final String INVOICE_EXPENSE_TITLE = /*$$(*/ "Invoice.expenseTitle"; /*)*/
-	
+
 	public static final String INVOICE_TIMESHEET_USER = /*$$(*/ "Invoice.timesheetUser"; /*)*/
 	public static final String INVOICE_TIMESHEET_ACTIVITY = /*$$(*/ "Invoice.timesheetActivity"; /*)*/
 	public static final String INVOICE_TIMESHEET_DURATION = /*$$(*/ "Invoice.timesheetDuration"; /*)*/
 
-	
+
 	public static final String INVOICE_EXPENSE_TOTAL_AMOUNT = /*$$(*/ "Invoice.expenseTotalAmount"; /*)*/
 	public static final String INVOICE_EXPENSE_TAX_AMOUNT = /*$$(*/ "Invoice.expenseTaxAmount"; /*)*/
 	public static final String INVOICE_EXPENSE_PRODUCT = /*$$(*/ "Invoice.expenseProduct"; /*)*/
 
 	public static final String INVOICE_PRODUCT_CODE = /*$$(*/ "Invoice.productCode"; /*)*/
 	public static final String INVOICE_TERMS_AND_CONDITIONS = /*$$(*/ "Invoice.termsAndConditions"; /*)*/
-	
+
 	public static final String INVOICE_SUBSCRIPTION_PERIOD = /*$$(*/ "Invoice.subscriptionPeriod"; /*)*/
 
-	
+
 	public static final String ACCOUNTING_REPORT_1_TITLE = /*$$(*/ "AccountingReportType1.title"; /*)*/
 	public static final String ACCOUNTING_REPORT_1_JOURNAL = /*$$(*/ "AccountingReportType1.journal"; /*)*/
 	public static final String ACCOUNTING_REPORT_1_COMPANY = /*$$(*/ "AccountingReportType1.company"; /*)*/
@@ -92,7 +91,7 @@ public interface ITranslation {
 	public static final String ACCOUNTING_REPORT_1_CREDIT = /*$$(*/ "AccountingReportType1.credit"; /*)*/
 	public static final String ACCOUNTING_REPORT_1_TOTAL = /*$$(*/ "AccountingReportType1.total"; /*)*/
 
-	
+
 	public static final String ACCOUNTING_REPORT_2_TITLE = /*$$(*/ "AccountingReportType2.title"; /*)*/
 	public static final String ACCOUNTING_REPORT_2_JOURNAL = /*$$(*/ "AccountingReportType2.journal"; /*)*/
 	public static final String ACCOUNTING_REPORT_2_COMPANY = /*$$(*/ "AccountingReportType2.company"; /*)*/
@@ -171,7 +170,7 @@ public interface ITranslation {
 	public static final String ACCOUNT_MOVE_PERIOD = /*$$(*/ "move.period"; /*)*/
 	public static final String ACCOUNT_MOVE_CURRENCY = /*$$(*/ "move.currency"; /*)*/
 	public static final String ACCOUNT_MOVE_COMPANY = /*$$(*/ "move.company"; /*)*/
-	
+
 	public static final String ACCOUNT_MOVE_LINE_DATE = /*$$(*/ "moveLine.date"; /*)*/
 	public static final String ACCOUNT_MOVE_LINE_PARTNER = /*$$(*/ "moveLine.partner"; /*)*/
 	public static final String ACCOUNT_MOVE_LINE_ACCOUNT = /*$$(*/ "moveLine.account"; /*)*/

--- a/axelor-account/src/main/resources/i18n/messages.csv
+++ b/axelor-account/src/main/resources/i18n/messages.csv
@@ -860,7 +860,6 @@
 "Invoice.invoiceAdvPaymentNo",,,
 "Invoice.invoiceBalanceNo",,,
 "Invoice.invoiceNo",,,
-"Invoice.law",,,
 "Invoice.note",,,
 "Invoice.of",,,
 "Invoice.paymentTerms",,,

--- a/axelor-account/src/main/resources/i18n/messages_en.csv
+++ b/axelor-account/src/main/resources/i18n/messages_en.csv
@@ -860,7 +860,6 @@
 "Invoice.invoiceAdvPaymentNo","ADVANCE INVOICE N°",,
 "Invoice.invoiceBalanceNo","BALANCE INVOICE N°",,
 "Invoice.invoiceNo","INVOICE N°",,
-"Invoice.law",,,
 "Invoice.note","Note",,
 "Invoice.of","of",,
 "Invoice.paymentTerms","Payment terms",,

--- a/axelor-account/src/main/resources/i18n/messages_fr.csv
+++ b/axelor-account/src/main/resources/i18n/messages_fr.csv
@@ -860,7 +860,6 @@
 "Invoice.invoiceAdvPaymentNo","FACTURE D'ACOMPTE N°",,
 "Invoice.invoiceBalanceNo","FACTURE DE SOLDE N°",,
 "Invoice.invoiceNo","FACTURE N°",,
-"Invoice.law","Dans le cadre de la loi N°92-1442 du décembre 1992 nous vous précisons que tout retard de paiement donnera lieu à une application d'une pénalité égale à une fois et demi le taux d'intérêt légal.",,
 "Invoice.note","Remarques",,
 "Invoice.of","de",,
 "Invoice.paymentTerms","Conditions de paiement",,

--- a/axelor-account/src/main/resources/reports/Invoice.rptdesign
+++ b/axelor-account/src/main/resources/reports/Invoice.rptdesign
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.23" id="1">
-    <property name="createdBy">Eclipse BIRT Designer Version 4.6.0.v201606072122</property>
+    <property name="createdBy">Eclipse BIRT Designer Version 4.7.0.v201706222054</property>
     <list-property name="propertyBindings">
         <structure>
             <property name="name">queryText</property>
@@ -4757,40 +4757,12 @@ row["partnerFirstName"]
                                 <cell id="5083"/>
                             </row>
                             <row id="5084">
-                                <cell id="5085"/>
-                                <cell id="5086"/>
-                                <cell id="5087"/>
-                                <cell id="5088"/>
                                 <cell id="5089">
-                                    <property name="colSpan">4</property>
+                                    <property name="colSpan">8</property>
                                     <property name="rowSpan">1</property>
-                                    <text id="5090">
-                                        <property name="fontSize">6pt</property>
-                                        <property name="dataSet">TranslateDS</property>
-                                        <list-property name="paramBindings">
-                                            <structure>
-                                                <property name="paramName">param_1</property>
-                                                <simple-property-list name="expression">
-                                                    <value type="javascript">'Invoice.law'</value>
-                                                </simple-property-list>
-                                            </structure>
-                                        </list-property>
-                                        <list-property name="boundDataColumns">
-                                            <structure>
-                                                <property name="name">key</property>
-                                                <text-property name="displayName">key</text-property>
-                                                <expression name="expression" type="javascript">dataSetRow["message_key"]</expression>
-                                                <property name="dataType">string</property>
-                                            </structure>
-                                            <structure>
-                                                <property name="name">translation</property>
-                                                <text-property name="displayName">translation</text-property>
-                                                <expression name="expression" type="javascript">dataSetRow["translation"]</expression>
-                                                <property name="dataType">string</property>
-                                            </structure>
-                                        </list-property>
+                                    <text id="5127">
                                         <property name="contentType">html</property>
-                                        <text-property name="content"><![CDATA[<VALUE-OF>row["translation"]</VALUE-OF>]]></text-property>
+                                        <text-property name="content"><![CDATA[<VALUE-OF format="HTML">row["ClientBox"]</VALUE-OF>]]></text-property>
                                     </text>
                                 </cell>
                                 <cell id="5091"/>

--- a/axelor-account/src/main/resources/views/AppInvoice.xml
+++ b/axelor-account/src/main/resources/views/AppInvoice.xml
@@ -2,11 +2,11 @@
 <object-views xmlns="http://axelor.com/xml/ns/object-views"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://axelor.com/xml/ns/object-views http://axelor.com/xml/ns/object-views/object-views_5.0.xsd">
-	
+
 	<form name="app-invoice-config-form" title="App invoice" model="com.axelor.apps.base.db.AppInvoice" canDelete="false" canNew="false" width="large">
 		<panel>
 			<field name="isInvoiceMoveConsolidated" widget="boolean-switch"/>
-            <field name="isVentilationSkipped" widget="boolean-switch"/>
+			<field name="isVentilationSkipped" widget="boolean-switch"/>
 		</panel>
 	</form>
 	


### PR DESCRIPTION
Replace hardcoded, misworded, obsolete statement present on French
invoices by the one that can be configured in company's invoicing
options and was never used.