### PR TITLE
sale order: properly hide "delivery address" title

### DIFF
--- a/axelor-sale/src/main/resources/reports/SaleOrder.rptdesign
+++ b/axelor-sale/src/main/resources/reports/SaleOrder.rptdesign
@@ -2794,7 +2794,7 @@ row["ClientPartFirstName"]
                         <list-property name="visibility">
                             <structure>
                                 <property name="format">all</property>
-                                <expression name="valueExpr" type="javascript">row._outer["invoicingAddress"]==null||row._outer["deliveryAddress"] == null|| row._outer["deliveryAddress"] == row._outer["invoicingAddress"]</expression>
+                                <expression name="valueExpr" type="javascript">row._outer["invoicingAddress"] == null || row._outer["invoicingAddress"] == ""</expression>
                             </structure>
                         </list-property>
                         <list-property name="paramBindings">
@@ -2840,7 +2840,7 @@ row["ClientPartFirstName"]
                         <list-property name="visibility">
                             <structure>
                                 <property name="format">all</property>
-                                <expression name="valueExpr" type="javascript">row._outer["invoicingAddress"] == row._outer["deliveryAddress"] || row._outer["deliveryAddress"] == null || row._outer["invoicingAddress"]  == null</expression>
+                                <expression name="valueExpr" type="javascript">row._outer["invoicingAddress"] == row._outer["deliveryAddress"] || row._outer["deliveryAddress"] == "" || row._outer["deliveryAddress"] == null</expression>
                             </structure>
                         </list-property>
                         <list-property name="paramBindings">


### PR DESCRIPTION
The conditions were rather strange, moreover deliveryAddress seems to be
an empty string rather than a null one when not filled.