### PR TITLE
invoice & order: properly display "note" title

### DIFF
--- a/axelor-account/src/main/resources/reports/Invoice.rptdesign
+++ b/axelor-account/src/main/resources/reports/Invoice.rptdesign
@@ -4817,15 +4817,14 @@ row["partnerFirstName"]
                                     <property name="colSpan">2</property>
                                     <property name="rowSpan">1</property>
                                     <text id="5104">
-                                        <property name="fontFamily">monospace</property>
-                                        <property name="fontSize">13pt</property>
+                                        <property name="fontSize">11pt</property>
                                         <property name="fontWeight">bold</property>
                                         <property name="color">#606062</property>
                                         <property name="dataSet">TranslateDS</property>
                                         <list-property name="visibility">
                                             <structure>
                                                 <property name="format">all</property>
-                                                <expression name="valueExpr" type="javascript">row._outer["note"] == null</expression>
+                                                <expression name="valueExpr" type="javascript">row._outer["note"] == null || row._outer["note"] == ""</expression>
                                             </structure>
                                         </list-property>
                                         <list-property name="paramBindings">

--- a/axelor-sale/src/main/resources/reports/SaleOrder.rptdesign
+++ b/axelor-sale/src/main/resources/reports/SaleOrder.rptdesign
@@ -5248,7 +5248,7 @@ row["ClientPartFirstName"]
                         <list-property name="visibility">
                             <structure>
                                 <property name="format">all</property>
-                                <expression name="valueExpr" type="javascript">row["description"] == null</expression>
+                                <expression name="valueExpr" type="javascript">row._outer["description"] == null || row._outer["description"] == ""</expression>
                             </structure>
                         </list-property>
                         <list-property name="paramBindings">


### PR DESCRIPTION
Fix font on invoices to have the same presentation as sale orders, fix
hidden expression for description title (it was never displayed)