### PR TITLE
purchases: fix order company bank details

### DIFF
--- a/axelor-purchase/src/main/resources/views/PurchaseOrder.xml
+++ b/axelor-purchase/src/main/resources/views/PurchaseOrder.xml
@@ -598,6 +598,11 @@
 	<action-method name="action-set-supplier-partner-domain">
 		<call class="com.axelor.apps.purchase.web.PurchaseOrderController" method="supplierPartnerDomain"/>
 	</action-method>
+	
+	<action-method name="action-purchase-order-method-fill-company-bank-details">
+		<call class="com.axelor.apps.purchase.web.PurchaseOrderController" method="fillCompanyBankDetails"/>
+	</action-method>
+	
 
 	<search-filters name="purchase-order-filters" model="com.axelor.apps.purchase.db.PurchaseOrder" title="Purchases Order filters">
 		<filter title="My RFQs">


### PR DESCRIPTION
Merge commit b0f38e6 seems to have been down after a hard night… Readd
missing action action-purchase-order-method-fill-company-bank-details
which was dropped then. The diff is to ugly for me to dig into to see if
more stuff was accidentaly dropped. I guess a git training won't hurt