### PR TITLE
sale/purchase: correctly update taxEquiv on taxLine change

### DIFF
--- a/axelor-base/src/main/java/com/axelor/apps/base/service/tax/FiscalPositionServiceImpl.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/service/tax/FiscalPositionServiceImpl.java
@@ -20,24 +20,28 @@ package com.axelor.apps.base.service.tax;
 import com.axelor.apps.account.db.FiscalPosition;
 import com.axelor.apps.account.db.Tax;
 import com.axelor.apps.account.db.TaxEquiv;
+import com.google.inject.Singleton;
 
+@Singleton
 public class FiscalPositionServiceImpl implements FiscalPositionService  {
 
-    public Tax getTax(FiscalPosition fiscalPosition, Tax tax)  {
-        TaxEquiv taxEquiv = getTaxEquiv(fiscalPosition, tax);
+	@Override
+	public Tax getTax(FiscalPosition fiscalPosition, Tax tax)  {
+		TaxEquiv taxEquiv = getTaxEquiv(fiscalPosition, tax);
 
-        return taxEquiv == null ? tax : taxEquiv.getToTax();
-    }
+		return taxEquiv == null ? tax : taxEquiv.getToTax();
+	}
 
+	@Override
 	public TaxEquiv getTaxEquiv(FiscalPosition fiscalPosition, Tax tax) {
-        if (fiscalPosition != null && fiscalPosition.getTaxEquivList() != null)  {
-            for (TaxEquiv taxEquiv : fiscalPosition.getTaxEquivList())  {
-                if (taxEquiv.getFromTax().equals(tax) && taxEquiv.getToTax() != null)  {
-                    return taxEquiv;
-                }
-            }
-        }
+		if (fiscalPosition != null && fiscalPosition.getTaxEquivList() != null)  {
+			for (TaxEquiv taxEquiv : fiscalPosition.getTaxEquivList())  {
+				if (taxEquiv.getFromTax().equals(tax) && taxEquiv.getToTax() != null)  {
+					return taxEquiv;
+				}
+			}
+		}
 
-        return null;
-    }
+		return null;
+	}
 }

--- a/axelor-purchase/src/main/java/com/axelor/apps/purchase/web/PurchaseOrderLineController.java
+++ b/axelor-purchase/src/main/java/com/axelor/apps/purchase/web/PurchaseOrderLineController.java
@@ -48,6 +48,9 @@ public class PurchaseOrderLineController {
 	@Inject
 	private PurchaseOrderLineService purchaseOrderLineService;
 
+	@Inject
+	private FiscalPositionService fiscalPositionService;
+
 	public void compute(ActionRequest request, ActionResponse response) throws AxelorException{
 
 		try{
@@ -145,7 +148,21 @@ public class PurchaseOrderLineController {
 
 	}
 
-	
+	public void getTaxEquiv(ActionRequest request, ActionResponse response) {
+
+		Context context = request.getContext();
+		PurchaseOrderLine purchaseOrderLine = context.asType(PurchaseOrderLine.class);
+		PurchaseOrder purchaseOrder = getPurchaseOrder(context);
+
+		response.setValue("taxEquiv", null);
+
+		if(purchaseOrder == null || purchaseOrderLine == null ||
+				purchaseOrder.getSupplierPartner() == null || purchaseOrderLine.getTaxLine() == null) return;
+
+		response.setValue("taxEquiv", fiscalPositionService.getTaxEquiv(purchaseOrder.getSupplierPartner().getFiscalPosition(), purchaseOrderLine.getTaxLine().getTax()));
+
+	}
+
 	public void getDiscount(ActionRequest request, ActionResponse response){
 
 		Context context = request.getContext();

--- a/axelor-purchase/src/main/resources/views/PurchaseOrderLine.xml
+++ b/axelor-purchase/src/main/resources/views/PurchaseOrderLine.xml
@@ -95,7 +95,7 @@
 				<field name="$qtyValid" hidden="true" colSpan="12"/>
 			</panel>
 			<field name="unit" canEdit="false" form-view="unit-form" grid-view="unit-grid"/>
-			<field name="taxLine" canEdit="false" onChange="action-purchase-order-line-method-convert-tax,action-purchase-order-line-method-compute,action-purchase-order-line-method-compute-analytic-distribution" domain="self.endDate = null or self.endDate &gt; :__date__" grid-view="tax-line-grid" form-view="tax-line-form"/>
+			<field name="taxLine" canEdit="false" onChange="action-group-purchase-purchase-orderline-taxline-onchange" domain="self.endDate = null or self.endDate &gt; :__date__" grid-view="tax-line-grid" form-view="tax-line-form"/>
 			<field name="price" onChange="action-purchase-order-line-method-compute,action-purchase-order-line-method-compute-analytic-distribution">
 				<hilite color="danger" if=" $number(saleMinPrice) &lt; $number(salePrice)"/>
 			</field>
@@ -104,7 +104,7 @@
 			<field name="inTaxTotal" readonly="true"/>
 			<field name="saleMinPrice" readonly="true"/>
 			<field name="salePrice" hidden="true"/>
-			   <field name="taxEquiv" hidden="true" grid-view="tax-equiv-grid" form-view="tax-equiv-form"/>
+			<field name="taxEquiv" hidden="true" grid-view="tax-equiv-grid" form-view="tax-equiv-form"/>
 		</panel>
 
 		<panel name="discount" title="Discount" canCollapse="true" hideIf="isTitleLine">
@@ -235,7 +235,14 @@
 		<action name="action-purchase-order-line-method-generate-suppliers-requests"/>
 		<action name="save"/>
 	</action-group>
-	
+
+	<action-group name="action-group-purchase-purchase-orderline-taxline-onchange">
+		<action name="action-purchase-order-line-method-get-tax-equiv"/>
+		<action name="action-purchase-order-line-method-convert-tax"/>
+		<action name="action-purchase-order-line-method-compute"/>
+		<action name="action-purchase-order-line-method-compute-analytic-distribution" if="__config__.app.isApp('supplychain') &amp;&amp; __config__.app.getApp('account').getManageAnalyticAccounting()"/>
+	</action-group>
+
 	<action-attrs name="action-purchase-order-line-attrs-delivery-panel">
 		<attribute name="hidden" for="deliveryPanel" expr="eval: product?.productTypeSelect != 'storable'"/>
 	</action-attrs>
@@ -296,6 +303,10 @@
 
 	<action-method name="action-purchase-order-line-method-check-qty">
 		<call class="com.axelor.apps.purchase.web.PurchaseOrderLineController" method="checkQty"/>
+	</action-method>
+
+	<action-method name="action-purchase-order-line-method-get-tax-equiv">
+		<call class="com.axelor.apps.purchase.web.PurchaseOrderLineController" method="getTaxEquiv"/>
 	</action-method>
 
 	<!-- ACTION ATTRS -->

--- a/axelor-sale/src/main/resources/views/SaleOrderLine.xml
+++ b/axelor-sale/src/main/resources/views/SaleOrderLine.xml
@@ -115,7 +115,7 @@
 				<field name="$availableStock" readonly="true" type="decimal" title="Available stock" if-module="axelor-supplychain" hideIf="typeSelect == 2" if="__config__.app.getApp('supplychain').getManageStockReservation()"/>
 				<button name="updateReservedQty" hidden="true" title="Change reserved qty" onClick="action-view-sale-order-line-reserved-qty-wizard" if-module="axelor-supplychain"/>
 				<field name="unit"  hideIf="typeSelect == 2" canEdit="false" form-view="unit-form" grid-view="unit-grid"/>
-				<field name="taxLine" canEdit="false" hideIf="typeSelect == 2" colSpan="4" onChange="action-sale-order-line-method-convert-tax,action-sale-order-line-method-compute,action-sale-order-line-method-compute-analytic-distribution" domain="self.endDate = null or self.endDate &gt; :__date__" grid-view="tax-line-grid" form-view="tax-line-form"/>
+				<field name="taxLine" canEdit="false" hideIf="typeSelect == 2" colSpan="4" onChange="action-group-sale-saleorderline-tax-line-onchange" domain="self.endDate = null or self.endDate &gt; :__date__" grid-view="tax-line-grid" form-view="tax-line-form"/>
 				<field name="taxEquiv" hidden="true" grid-view="tax-equiv-grid" form-view="tax-equiv-form"/>
 				<field name="price"  hideIf="typeSelect == 2" onChange="action-sale-order-line-method-compute,action-sale-order-line-method-compute-analytic-distribution" colSpan="4"/>
 				<field name="priceDiscounted" colSpan="4" hidden="true"/>
@@ -189,7 +189,7 @@
 			<field name="productName"/>
 			<field name="qty"  hideIf="typeSelect == 2" onChange="action-group-sale-saleorderline-qty-onchange" readonlyIf="typeSelect == 2"/>
 			<field name="unit"  hideIf="typeSelect == 2" canEdit="false" form-view="unit-form" grid-view="unit-grid"/>
-			<field name="taxLine"  hideIf="typeSelect == 2" colSpan="4" onChange="action-sale-order-line-method-convert-tax,action-sale-order-line-method-compute,action-sale-order-line-method-compute-analytic-distribution" domain="self.endDate = null or self.endDate &gt; :__date__" grid-view="tax-line-grid" form-view="tax-line-form"/>
+			<field name="taxLine"  hideIf="typeSelect == 2" colSpan="4" onChange="action-group-sale-saleorderline-tax-line-onchange" domain="self.endDate = null or self.endDate &gt; :__date__" grid-view="tax-line-grid" form-view="tax-line-form"/>
 			<field name="taxEquiv" hidden="true" grid-view="tax-equiv-grid" form-view="tax-equiv-form"/>
 			<field name="price"  hideIf="typeSelect == 2" onChange="action-sale-order-line-method-compute,action-sale-order-line-method-compute-analytic-distribution" colSpan="4"/>
 			<field name="priceDiscounted" colSpan="4" hidden="true"/>
@@ -329,6 +329,13 @@
 		<action name="action-sale-order-line-method-check-qty"/>
     </action-group>
 
+	<action-group name="action-group-sale-saleorderline-tax-line-onchange">
+		<action name="action-sale-order-line-method-get-tax-equiv"/>
+		<action name="action-sale-order-line-method-convert-tax"/>
+		<action name="action-sale-order-line-method-compute"/>
+		<action name="action-sale-order-line-method-compute-analytic-distribution" if="__config__.app.isApp('supplychain') &amp;&amp; __config__.app.getApp('account').getManageAnalyticAccounting()"/>
+	</action-group>
+
     <action-group name="action-group-sale-saleorderline-salesupplyselect-onchange" if-module="axelor-production">
     	<action name="action-sale-order-line-get-production-information" if="__config__.app.isApp('production')"/>
 		<action name="action-sale-order-line-method-supplier-partner-default" if="__config__.app.isApp('production')"/>
@@ -412,7 +419,11 @@
 	<action-method name="action-sale-order-line-method-check-qty">
 		<call class="com.axelor.apps.sale.web.SaleOrderLineController" method="checkQty"/>
 	</action-method>
-	
+
+	<action-method name="action-sale-order-line-method-get-tax-equiv">
+		<call class="com.axelor.apps.sale.web.SaleOrderLineController" method="getTaxEquiv"/>
+	</action-method>
+
   	<!-- ACTION ATTRS -->
     
     <action-attrs name="action-sale-order-line-attrs-hide-bill-of-material" if-module="axelor-production">


### PR DESCRIPTION
taxEquiv was only set when product was selected, making it inconsistent
in case of tax change. This was also preventing the popup to close
because of invalid taxEquiv field if taxLine was cleared.