### PR TITLE
#12665-CRM(Leads). All fields in the fullName editor appears now, even on readonly mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Also, improve the sale order line grid and form views.
 - Fix line removal in confirmed sale order.
 - Product: fix printing catalog of selected products.
 - Product: fix missing pictures in catalog when not all products have pictures.
+- Fix on Leads (CRM) : All fields in the fullName editor appears now, even on readonly mode.
 
 
 ## [5.0.0] - 2018-06-13

--- a/axelor-crm/src/main/resources/views/Lead.xml
+++ b/axelor-crm/src/main/resources/views/Lead.xml
@@ -84,7 +84,7 @@
 				</field>
 				<static name="duplicateLeadText" hidden="true" colSpan="12"><![CDATA[<span class='label label-warning'>There is already a lead with this name.</span>]]></static>
 				<field name="fullName" showTitle="false" colSpan="12" readonlyIf="statusSelect == 4 || statusSelect == 5">
-					<editor x-show-titles="false">
+					<editor x-show-titles="false" x-viewer="true">
 						<field name="enterpriseName" colSpan="12" showIf="partner == null" placeholder="Enterprise name" onChange="action-lead-method-set-social-network-url"/>
 						<field name="jobTitle" colSpan="6" placeholder="Function"/>
 						<field name="industrySector" colSpan="6" form-view="industry-sector-form" grid-view="industry-sector-grid"/>


### PR DESCRIPTION
All fields in the fullName editor appears now, even on readonly mode.