### PR TITLE
account: slightly improve account creation from partner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Solved an issue linked to having a manufacturing order with a planned quantity of 0.
 - Fix mass invoicing of stock moves sometimes opening up unrelated forms when trying to open a single stock move for more details.
 - Improve exception handling in supplychain demo.
+- Account: use partner name as default account name when creating from partner's account configuration screen
 
 ## Bug Fixes
 - Fix on prod process report.

--- a/axelor-account/src/main/resources/views/Account.xml
+++ b/axelor-account/src/main/resources/views/Account.xml
@@ -122,6 +122,7 @@
 
     <!-- action-record shared among customer/supplier/employee account -->
     <action-record name="action-account-record-new-from-partner" model="com.axelor.apps.account.db.Account">
+        <field name="name" expr="eval:__parent__.partner.fullName"/>
         <field name="company" expr="eval: __parent__.company"/>
         <field name="useForPartnerBalance" expr="eval: true"/>
         <field name="reconcileOk" expr="eval: true"/>


### PR DESCRIPTION
Addendum to commit 22d3e31, use partner name as default name for created
account.