### PR TITLE
account: allow both substitution and reverseCharge on TaxEquiv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## Improvements
 - Show full name for products in Mrp report.
 - Sale and Purchase order form: Remove edit from stockLocation field.
+- Account: allow to have substitution & reverse charge on the same tax equivalence.
 - PERIOD : allow to reopen a period if the fiscal year is not closed
 - Currency conversion: allow to fetch today's rate on newly created conversion lines.
 - Remove unecessary table in VAT on invoice report.

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/AccountManagementServiceAccountImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/AccountManagementServiceAccountImpl.java
@@ -23,9 +23,13 @@ import com.axelor.apps.account.exception.IExceptionMessage;
 import com.axelor.apps.base.db.Company;
 import com.axelor.apps.base.db.Product;
 import com.axelor.apps.base.service.tax.AccountManagementServiceImpl;
+import com.axelor.apps.base.service.tax.FiscalPositionService;
+import com.axelor.apps.base.service.tax.TaxService;
 import com.axelor.exception.AxelorException;
 import com.axelor.exception.db.repo.TraceBackRepository;
 import com.axelor.i18n.I18n;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +38,12 @@ public class AccountManagementServiceAccountImpl extends AccountManagementServic
     implements AccountManagementAccountService {
 
   private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Inject
+  public AccountManagementServiceAccountImpl(
+      FiscalPositionService fiscalPositionService, TaxService taxService) {
+    super(fiscalPositionService, taxService);
+  }
 
   /**
    * Obtenir le compte comptable d'un produit.

--- a/axelor-base/src/main/java/com/axelor/apps/base/service/tax/AccountManagementServiceImpl.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/service/tax/AccountManagementServiceImpl.java
@@ -28,6 +28,8 @@ import com.axelor.apps.base.exceptions.IExceptionMessage;
 import com.axelor.exception.AxelorException;
 import com.axelor.exception.db.repo.TraceBackRepository;
 import com.axelor.i18n.I18n;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import java.lang.invoke.MethodHandles;
 import java.time.LocalDate;
 import java.util.List;
@@ -37,6 +39,17 @@ import org.slf4j.LoggerFactory;
 public class AccountManagementServiceImpl implements AccountManagementService {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private FiscalPositionService fiscalPositionService;
+
+  private TaxService taxService;
+
+  @Inject
+  public AccountManagementServiceImpl(
+      FiscalPositionService fiscalPositionService, TaxService taxService) {
+    this.fiscalPositionService = fiscalPositionService;
+    this.taxService = taxService;
+  }
 
   /**
    * Obtenir la bonne configuration comptable en fonction du produit et de la société.
@@ -139,10 +152,9 @@ public class AccountManagementServiceImpl implements AccountManagementService {
         new Object[] {product.getCode(), company.getName(), isPurchase});
 
     Tax tax =
-        new FiscalPositionServiceImpl()
-            .getTax(
-                fiscalPosition,
-                this.getProductTax(this.getAccountManagement(product, company), isPurchase));
+        fiscalPositionService.getTax(
+            fiscalPosition,
+            this.getProductTax(this.getAccountManagement(product, company), isPurchase));
 
     if (tax != null) {
       return tax;
@@ -191,8 +203,8 @@ public class AccountManagementServiceImpl implements AccountManagementService {
       throws AxelorException {
 
     TaxLine taxLine =
-        new TaxService()
-            .getTaxLine(this.getProductTax(product, company, fiscalPosition, isPurchase), date);
+        taxService.getTaxLine(
+            this.getProductTax(product, company, fiscalPosition, isPurchase), date);
     if (taxLine != null) {
       return taxLine;
     }

--- a/axelor-base/src/main/java/com/axelor/apps/base/service/tax/TaxService.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/service/tax/TaxService.java
@@ -24,9 +24,11 @@ import com.axelor.apps.tool.date.DateTool;
 import com.axelor.exception.AxelorException;
 import com.axelor.exception.db.repo.TraceBackRepository;
 import com.axelor.i18n.I18n;
+import com.google.inject.Singleton;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+@Singleton
 public class TaxService {
 
   /**

--- a/axelor-base/src/main/resources/domains/TaxEquiv.xml
+++ b/axelor-base/src/main/resources/domains/TaxEquiv.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<domain-models xmlns="http://axelor.com/xml/ns/domain-models"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://axelor.com/xml/ns/domain-models http://axelor.com/xml/ns/domain-models/domain-models_5.0.xsd">
+<domain-models xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns="http://axelor.com/xml/ns/domain-models"
+               xsi:schemaLocation="http://axelor.com/xml/ns/domain-models http://axelor.com/xml/ns/domain-models/domain-models_5.0.xsd">
 
-  <module name="account" package="com.axelor.apps.account.db"/>
+    <module name="account" package="com.axelor.apps.account.db"/>
 
-  <entity name="TaxEquiv" lang="java">
-  
-    <many-to-one name="fiscalPosition" ref="com.axelor.apps.account.db.FiscalPosition" title="Fiscal position"/>
-    <many-to-one name="fromTax" ref="com.axelor.apps.account.db.Tax" title="Tax to replace"/>
-    <many-to-one name="toTax" ref="com.axelor.apps.account.db.Tax" title="Replacement Tax"/>
-    <string name="specificNote" title="Specific note" large="true"/>
-    <boolean name="reverseCharge" title="Reverse Charge"/>
-    <many-to-one name="reverseChargeTax" ref="com.axelor.apps.account.db.Tax" title="Reverse Charge Tax"/>
-  </entity>
+    <entity name="TaxEquiv" lang="java">
+
+        <many-to-one name="fiscalPosition" ref="com.axelor.apps.account.db.FiscalPosition" title="Fiscal position"/>
+        <many-to-one name="fromTax" ref="com.axelor.apps.account.db.Tax" title="Tax to replace"/>
+        <many-to-one name="toTax" ref="com.axelor.apps.account.db.Tax" title="Replacement Tax"/>
+        <string name="specificNote" title="Specific note" large="true"/>
+        <boolean name="reverseCharge" title="Reverse Charge"/>
+        <many-to-one name="reverseChargeTax" ref="com.axelor.apps.account.db.Tax" title="Reverse Charge Tax"/>
+
+        <unique-constraint columns="fiscalPosition,fromTax"/>
+    </entity>
 
 </domain-models>

--- a/axelor-base/src/main/resources/views/TaxEquiv.xml
+++ b/axelor-base/src/main/resources/views/TaxEquiv.xml
@@ -13,21 +13,15 @@
         <panel name="main">
             <field name="fromTax" form-view="tax-form" grid-view="tax-grid"/>
             <field name="toTax" form-view="tax-form" grid-view="tax-grid"/>
-            <field name="reverseCharge" onChange="action-tax-equiv-attrs-hide-to-tax"/>
-            <field name="reverseChargeTax" form-view="tax-form" grid-view="tax-grid" hidden="true" showIf="reverseCharge"/>
+            <field name="reverseCharge" />
+            <field name="reverseChargeTax" form-view="tax-form" grid-view="tax-grid" showIf="reverseCharge"/>
             <field name="specificNote" colSpan="12" hidden="true"/>
         </panel>
     </form>
 
     <action-group name="action-tax-equiv-group-onload">
-        <action name="action-tax-equiv-attrs-hide-to-tax"/>
         <action name="action-tax-equiv-attrs-hide-specific-note"/>
     </action-group>
-
-    <action-attrs name="action-tax-equiv-attrs-hide-to-tax">
-        <attribute for="toTax" name="value" expr="eval: fromTax" if="reverseCharge"/>
-        <attribute for="toTax" name="hidden" expr="eval: reverseCharge"/>
-    </action-attrs>
 
     <action-attrs name="action-tax-equiv-attrs-hide-specific-note">
         <attribute for="specificNote" name="hidden" expr="eval: __parent__?.customerSpecificNote"/>


### PR DESCRIPTION
Standard accounting rules for intra-EU VAT is as follow in France (for a standard rate VAT):

- French VAT account is replaced by intra-EU VAT account;
- Reverse charging is done on the opposite intra-EU VAT account.

For a purchase invoice it gives:

 - 4456xx is replaced by 445662
 - reverse charge is done on 4452xx

So we've to be able to both replace and reverse charge at the same time.
