### PR TITLE
account: add an option to allow editing of validated move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Improvements
 - Show full name for products in Mrp report.
 - Sale and Purchase order form: Remove edit from stockLocation field.
+- Account: add option to allow modification of validated but not-yet-exported moves.
 - PERIOD : allow to reopen a period if the fiscal year is not closed
 
 ## Bug Fixes

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveValidateService.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveValidateService.java
@@ -163,6 +163,7 @@ public class MoveValidateService {
 
     this.validateEquiponderanteMove(move);
     this.fillMoveLines(move);
+    move.setStatusSelect(MoveRepository.STATUS_VALIDATED);
     moveRepository.save(move);
 
     moveCustAccountService.updateCustomerAccount(move);
@@ -209,7 +210,6 @@ public class MoveValidateService {
             totalDebit,
             totalCredit);
       }
-      move.setStatusSelect(MoveRepository.STATUS_VALIDATED);
     }
   }
 

--- a/axelor-account/src/main/java/com/axelor/apps/account/web/MoveController.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/web/MoveController.java
@@ -23,11 +23,13 @@ import com.axelor.apps.account.db.MoveLine;
 import com.axelor.apps.account.db.repo.MoveRepository;
 import com.axelor.apps.account.exception.IExceptionMessage;
 import com.axelor.apps.account.report.IReport;
+import com.axelor.apps.account.service.move.MoveCustAccountService;
 import com.axelor.apps.account.service.move.MoveService;
 import com.axelor.apps.base.db.repo.YearRepository;
 import com.axelor.apps.base.service.PeriodService;
 import com.axelor.apps.report.engine.ReportSettings;
 import com.axelor.exception.AxelorException;
+import com.axelor.exception.ResponseMessageType;
 import com.axelor.exception.service.TraceBackService;
 import com.axelor.i18n.I18n;
 import com.axelor.inject.Beans;
@@ -42,9 +44,21 @@ import java.util.List;
 @Singleton
 public class MoveController {
 
-  @Inject protected MoveService moveService;
+  protected MoveService moveService;
 
-  @Inject protected MoveRepository moveRepo;
+  protected MoveRepository moveRepo;
+
+  protected MoveCustAccountService moveCustAccountService;
+
+  @Inject
+  public MoveController(
+      MoveService moveService,
+      MoveRepository moveRepository,
+      MoveCustAccountService moveCustAccountService) {
+    this.moveService = moveService;
+    this.moveRepo = moveRepository;
+    this.moveCustAccountService = moveCustAccountService;
+  }
 
   public void validate(ActionRequest request, ActionResponse response) {
 
@@ -107,6 +121,22 @@ public class MoveController {
       }
     } catch (Exception e) {
       TraceBackService.trace(response, e);
+    }
+  }
+
+  public void validateConsistency(ActionRequest request, ActionResponse response) {
+    try {
+      moveService.checkConsistency(request.getContext().asType(Move.class));
+    } catch (Exception e) {
+      TraceBackService.trace(response, e, ResponseMessageType.ERROR);
+    }
+  }
+
+  public void updatePartnerAccount(ActionRequest request, ActionResponse response) {
+    try {
+      moveCustAccountService.updateCustomerAccount(request.getContext().asType(Move.class));
+    } catch (Exception e) {
+      TraceBackService.trace(response, e, ResponseMessageType.ERROR);
     }
   }
 

--- a/axelor-account/src/main/resources/domains/AccountConfig.xml
+++ b/axelor-account/src/main/resources/domains/AccountConfig.xml
@@ -1,148 +1,150 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<domain-models xmlns="http://axelor.com/xml/ns/domain-models"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://axelor.com/xml/ns/domain-models http://axelor.com/xml/ns/domain-models/domain-models_5.0.xsd">
+<domain-models xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns="http://axelor.com/xml/ns/domain-models"
+               xsi:schemaLocation="http://axelor.com/xml/ns/domain-models http://axelor.com/xml/ns/domain-models/domain-models_5.0.xsd">
 
-	<module name="account" package="com.axelor.apps.account.db"/>
+    <module name="account" package="com.axelor.apps.account.db"/>
 
-	<entity name="AccountConfig" lang="java" cachable="true">
+    <entity name="AccountConfig" lang="java" cachable="true">
 
-		<one-to-one name="company" ref="com.axelor.apps.base.db.Company" title="Company" required="true" unique="true"/>
+        <one-to-one name="company" ref="com.axelor.apps.base.db.Company" title="Company" required="true" unique="true"/>
 
-		<!-- JOURNAL -->
-		<many-to-one name="customerSalesJournal" ref="com.axelor.apps.account.db.Journal" title="Sales Journal"/>
-		<many-to-one name="customerCreditNoteJournal" ref="com.axelor.apps.account.db.Journal" title="Customer Credit note Journal"/>
-		<many-to-one name="supplierPurchaseJournal" ref="com.axelor.apps.account.db.Journal" title="Supplier Purchase Journal"/>
-		<many-to-one name="supplierCreditNoteJournal" ref="com.axelor.apps.account.db.Journal" title="Supplier Credit Note Journal"/>
-		<many-to-one name="rejectJournal" ref="com.axelor.apps.account.db.Journal" title="Rejects journal"/>
-		<many-to-one name="accountClearanceJournal" ref="com.axelor.apps.account.db.Journal" title="Account clearance journal"/>
-		<many-to-one name="reimbursementJournal" ref="com.axelor.apps.account.db.Journal" title="Reimbursement Journal"/>
-		<many-to-one name="irrecoverableJournal" ref="com.axelor.apps.account.db.Journal" title="Irrecoverable Journal"/>
-		<many-to-one name="autoMiscOpeJournal" ref="com.axelor.apps.account.db.Journal" title="Auto Misc. Operation Journal"/>
-		<many-to-one name="manualMiscOpeJournal" ref="com.axelor.apps.account.db.Journal" title="Manual Misc. Operation Journal"/>
+        <!-- JOURNAL -->
+        <many-to-one name="customerSalesJournal" ref="com.axelor.apps.account.db.Journal" title="Sales Journal"/>
+        <many-to-one name="customerCreditNoteJournal" ref="com.axelor.apps.account.db.Journal" title="Customer Credit note Journal"/>
+        <many-to-one name="supplierPurchaseJournal" ref="com.axelor.apps.account.db.Journal" title="Supplier Purchase Journal"/>
+        <many-to-one name="supplierCreditNoteJournal" ref="com.axelor.apps.account.db.Journal" title="Supplier Credit Note Journal"/>
+        <many-to-one name="rejectJournal" ref="com.axelor.apps.account.db.Journal" title="Rejects journal"/>
+        <many-to-one name="accountClearanceJournal" ref="com.axelor.apps.account.db.Journal" title="Account clearance journal"/>
+        <many-to-one name="reimbursementJournal" ref="com.axelor.apps.account.db.Journal" title="Reimbursement Journal"/>
+        <many-to-one name="irrecoverableJournal" ref="com.axelor.apps.account.db.Journal" title="Irrecoverable Journal"/>
+        <many-to-one name="autoMiscOpeJournal" ref="com.axelor.apps.account.db.Journal" title="Auto Misc. Operation Journal"/>
+        <many-to-one name="manualMiscOpeJournal" ref="com.axelor.apps.account.db.Journal" title="Manual Misc. Operation Journal"/>
 
-		<many-to-one name="saleJournalType" ref="com.axelor.apps.account.db.JournalType" title="Sales journal type"/>
-		<many-to-one name="purchaseJournalType" ref="com.axelor.apps.account.db.JournalType" title="Purchase journal type"/>
-		<many-to-one name="cashJournalType" ref="com.axelor.apps.account.db.JournalType" title="Cash journal type"/>
-		<many-to-one name="creditNoteJournalType" ref="com.axelor.apps.account.db.JournalType" title="Credit note journal type"/>
+        <many-to-one name="saleJournalType" ref="com.axelor.apps.account.db.JournalType" title="Sales journal type"/>
+        <many-to-one name="purchaseJournalType" ref="com.axelor.apps.account.db.JournalType" title="Purchase journal type"/>
+        <many-to-one name="cashJournalType" ref="com.axelor.apps.account.db.JournalType" title="Cash journal type"/>
+        <many-to-one name="creditNoteJournalType" ref="com.axelor.apps.account.db.JournalType" title="Credit note journal type"/>
 
 
-		<!-- ACCOUNT -->
-		<many-to-one name="customerAccount" ref="com.axelor.apps.account.db.Account" title="Customer account"/>
-		<many-to-one name="supplierAccount" ref="com.axelor.apps.account.db.Account" title="Supplier account"/>
-		<many-to-one name="doubtfulCustomerAccount" ref="com.axelor.apps.account.db.Account" title="Doubtful customers account"/>
-		<many-to-one name="employeeAccount" ref="com.axelor.apps.account.db.Account" title="Employee account"/>
-		<many-to-one name="irrecoverableAccount" ref="com.axelor.apps.account.db.Account" title="Irrecoverable account"/>
-		<many-to-one name="cashPositionVariationAccount" ref="com.axelor.apps.account.db.Account" title="Cashier Regulation account"/>
-		<many-to-one name="advancePaymentAccount" ref="com.axelor.apps.account.db.Account" title="Advance Payment Account"/>
-		<many-to-one name="factorDebitAccount" ref="com.axelor.apps.account.db.Account"/>
-		<many-to-one name="factorCreditAccount" ref="com.axelor.apps.account.db.Account"/>
+        <!-- ACCOUNT -->
+        <many-to-one name="customerAccount" ref="com.axelor.apps.account.db.Account" title="Customer account"/>
+        <many-to-one name="supplierAccount" ref="com.axelor.apps.account.db.Account" title="Supplier account"/>
+        <many-to-one name="doubtfulCustomerAccount" ref="com.axelor.apps.account.db.Account" title="Doubtful customers account"/>
+        <many-to-one name="employeeAccount" ref="com.axelor.apps.account.db.Account" title="Employee account"/>
+        <many-to-one name="irrecoverableAccount" ref="com.axelor.apps.account.db.Account" title="Irrecoverable account"/>
+        <many-to-one name="cashPositionVariationAccount" ref="com.axelor.apps.account.db.Account" title="Cashier Regulation account"/>
+        <many-to-one name="advancePaymentAccount" ref="com.axelor.apps.account.db.Account" title="Advance Payment Account"/>
+        <many-to-one name="factorDebitAccount" ref="com.axelor.apps.account.db.Account"/>
+        <many-to-one name="factorCreditAccount" ref="com.axelor.apps.account.db.Account"/>
 
-		<decimal name="thresholdDistanceFromRegulation" title="Allowed payment range"/>
+        <decimal name="thresholdDistanceFromRegulation" title="Allowed payment range"/>
 
-		<boolean name="autoReconcileOnInvoice" title="Authorize auto reconcile on invoice"/>
-		<boolean name="autoReconcileOnPayment" title="Authorize auto reconcile on payment"/>
+        <boolean name="autoReconcileOnInvoice" title="Authorize auto reconcile on invoice"/>
+        <boolean name="autoReconcileOnPayment" title="Authorize auto reconcile on payment"/>
 
-		<many-to-one name="payingBackTax" ref="com.axelor.apps.account.db.Tax" title="Tax for management fee"/>
+        <many-to-one name="payingBackTax" ref="com.axelor.apps.account.db.Tax" title="Tax for management fee"/>
 
-		<!-- Default Payment Modes -->
-		<many-to-one name="inPaymentMode" ref="com.axelor.apps.account.db.PaymentMode" title="Incoming Payment Mode"/>
-		<many-to-one name="outPaymentMode" ref="com.axelor.apps.account.db.PaymentMode" title="Outgoing Payment Mode"/>
+        <!-- Default Payment Modes -->
+        <many-to-one name="inPaymentMode" ref="com.axelor.apps.account.db.PaymentMode" title="Incoming Payment Mode"/>
+        <many-to-one name="outPaymentMode" ref="com.axelor.apps.account.db.PaymentMode" title="Outgoing Payment Mode"/>
 
-		<!-- Default Payment Condition -->
-		<many-to-one name="defPaymentCondition" ref="com.axelor.apps.account.db.PaymentCondition" title="Default Payment Condition"/>
+        <!-- Default Payment Condition -->
+        <many-to-one name="defPaymentCondition" ref="com.axelor.apps.account.db.PaymentCondition" title="Default Payment Condition"/>
 
-		<!-- Onglet CFONB -->
-		<many-to-one name="cfonbConfig" ref="com.axelor.apps.account.db.CfonbConfig" title="Cfonb configuration"/>
+        <!-- Onglet CFONB -->
+        <many-to-one name="cfonbConfig" ref="com.axelor.apps.account.db.CfonbConfig" title="Cfonb configuration"/>
 
-		<!-- Doubtful Cust. -->
-		<string name="sixMonthDebtPassReason" title="Shift Reason (long term debt)" default="Receivables over 6 months"/>
-		<string name="threeMonthDebtPassReason" title="Shift Reason (short term debt)" default="Receivables over 3 months"/>
-		<integer name="sixMonthDebtMonthNumber" title="Long term debt duration (month)" default="6"/>
-		<integer name="threeMonthDebtMontsNumber" title="Short term debt duration (month)" default="3"/>
+        <!-- Doubtful Cust. -->
+        <string name="sixMonthDebtPassReason" title="Shift Reason (long term debt)" default="Receivables over 6 months"/>
+        <string name="threeMonthDebtPassReason" title="Shift Reason (short term debt)" default="Receivables over 3 months"/>
+        <integer name="sixMonthDebtMonthNumber" title="Long term debt duration (month)" default="6"/>
+        <integer name="threeMonthDebtMontsNumber" title="Short term debt duration (month)" default="3"/>
 
-		<!-- DebtRecovery -->
-		<one-to-many name="debtRecoveryConfigLineList" ref="com.axelor.apps.account.db.DebtRecoveryConfigLine" mappedBy="accountConfig" title="Debt recovery configuration table"/>
-		<integer name="mailTransitTime" title="Mail transit time"/>
-		<many-to-one name="factorPartner" ref="com.axelor.apps.base.db.Partner" title="Factor"/>
+        <!-- DebtRecovery -->
+        <one-to-many name="debtRecoveryConfigLineList" ref="com.axelor.apps.account.db.DebtRecoveryConfigLine" mappedBy="accountConfig" title="Debt recovery configuration table"/>
+        <integer name="mailTransitTime" title="Mail transit time"/>
+        <many-to-one name="factorPartner" ref="com.axelor.apps.base.db.Partner" title="Factor"/>
 
-		<!-- Reimbursement -->
-		<string name="reimbursementExportFolderPathCFONB" title="Path for reimbursement files (CFONB)"/>
-		<string name="reimbursementExportFolderPath" title="Path for reimbursement files (SEPA)"/>
-		<decimal name="lowerThresholdReimbursement" title="Lower reimbursement limit"/>
-		<decimal name="upperThresholdReimbursement" title="Upper reimbursement limit"/>
-		<many-to-one name="reimbursementAccount" ref="com.axelor.apps.account.db.Account" title="Reimbursement account"/>
-		<many-to-one name="reimbursementTemplate" ref="com.axelor.apps.message.db.Template" title="Reimbursement email template"/>
+        <!-- Reimbursement -->
+        <string name="reimbursementExportFolderPathCFONB" title="Path for reimbursement files (CFONB)"/>
+        <string name="reimbursementExportFolderPath" title="Path for reimbursement files (SEPA)"/>
+        <decimal name="lowerThresholdReimbursement" title="Lower reimbursement limit"/>
+        <decimal name="upperThresholdReimbursement" title="Upper reimbursement limit"/>
+        <many-to-one name="reimbursementAccount" ref="com.axelor.apps.account.db.Account" title="Reimbursement account"/>
+        <many-to-one name="reimbursementTemplate" ref="com.axelor.apps.message.db.Template" title="Reimbursement email template"/>
 
-		<string name="reimbursementImportFolderPathCFONB" title="Filepath for rejected reimbursements"/>
-		<string name="tempReimbImportFolderPathCFONB" title="Filepath for temporary rejected reimbursements import"/>
+        <string name="reimbursementImportFolderPathCFONB" title="Filepath for rejected reimbursements"/>
+        <string name="tempReimbImportFolderPathCFONB" title="Filepath for temporary rejected reimbursements import"/>
 
-		<string name="exportPath" title="Filepath for exported files (Accounting)"/>
-		<string name="exportFileName" title="File name for payroll journal entries"/>
+        <string name="exportPath" title="Filepath for exported files (Accounting)"/>
+        <string name="exportFileName" title="File name for payroll journal entries"/>
 
-		<!-- Onglet Prélèvements -->
-		<string name="paymentScheduleExportFolderPathCFONB" title="Filepath for direct debit exports (CFONB)"/>
+        <!-- Onglet Prélèvements -->
+        <string name="paymentScheduleExportFolderPathCFONB" title="Filepath for direct debit exports (CFONB)"/>
 
-		<many-to-one name="directDebitPaymentMode" ref="com.axelor.apps.account.db.PaymentMode" title="Payment mode for direct debit"/>
-		<many-to-one name="rejectionPaymentMode" ref="com.axelor.apps.account.db.PaymentMode" title="Payment mode after rejection"/>
-		<integer name="paymentScheduleRejectNumLimit" title="Max Nbr. for payment schedule rejection"/>
-		<integer name="invoiceRejectNumLimit" title="Max Nbr. of invoices rejection"/>
-		<string name="rejectImportPathAndFileName" title="Filepath to import rejected records"/>
-		<string name="tempImportPathAndFileName" title="Temporary filepath to import rejected records"/>
-		<many-to-one name="rejectPaymentScheduleTemplate" ref="com.axelor.apps.message.db.Template" title="Email template for invoice and payment schedule rejections"/>
+        <many-to-one name="directDebitPaymentMode" ref="com.axelor.apps.account.db.PaymentMode" title="Payment mode for direct debit"/>
+        <many-to-one name="rejectionPaymentMode" ref="com.axelor.apps.account.db.PaymentMode" title="Payment mode after rejection"/>
+        <integer name="paymentScheduleRejectNumLimit" title="Max Nbr. for payment schedule rejection"/>
+        <integer name="invoiceRejectNumLimit" title="Max Nbr. of invoices rejection"/>
+        <string name="rejectImportPathAndFileName" title="Filepath to import rejected records"/>
+        <string name="tempImportPathAndFileName" title="Temporary filepath to import rejected records"/>
+        <many-to-one name="rejectPaymentScheduleTemplate" ref="com.axelor.apps.message.db.Template" title="Email template for invoice and payment schedule rejections"/>
 
-		<!-- Onglet Apurements -->
-		<many-to-many name="clearanceAccountSet" ref="com.axelor.apps.account.db.Account" title="Clearance Accounts"/>
-		<many-to-one name="profitAccount" ref="com.axelor.apps.account.db.Account" title="Profit accounts"/>
-		<many-to-one name="standardRateTax" ref="com.axelor.apps.account.db.Tax" title="Tax standard rate for clearance"/>
+        <!-- Onglet Apurements -->
+        <many-to-many name="clearanceAccountSet" ref="com.axelor.apps.account.db.Account" title="Clearance Accounts"/>
+        <many-to-one name="profitAccount" ref="com.axelor.apps.account.db.Account" title="Profit accounts"/>
+        <many-to-one name="standardRateTax" ref="com.axelor.apps.account.db.Tax" title="Tax standard rate for clearance"/>
 
-		<string name="irrecoverableReasonPassage" title="Irrecoverable shifting reason" default="Manual shift into irrecoverable receivables"/>
-		<many-to-one name="irrecoverableStandardRateTax" ref="com.axelor.apps.account.db.Tax" title="Tax standard rate for irrecoverables"/>
+        <string name="irrecoverableReasonPassage" title="Irrecoverable shifting reason" default="Manual shift into irrecoverable receivables"/>
+        <many-to-one name="irrecoverableStandardRateTax" ref="com.axelor.apps.account.db.Tax" title="Tax standard rate for irrecoverables"/>
 
-		<!-- Onglet Paybox -->
-		<many-to-one name="payboxConfig" ref="com.axelor.apps.account.db.PayboxConfig" title="Paybox configuration"/>
+        <!-- Onglet Paybox -->
+        <many-to-one name="payboxConfig" ref="com.axelor.apps.account.db.PayboxConfig" title="Paybox configuration"/>
 
-		<!-- Invoice page -->
-		<boolean name="allowCancelVentilatedInvoice" title="Allow cancelation of ventilated invoice"/>
-		<boolean name="allowRemovalValidatedMove" title="Allow removal of validated move"/>
-		<boolean name="generateMoveForInvoicePayment" title="Generate move for payment on invoice" default="true"/>
-		<boolean name="generateMoveForAdvancePayment" title="Generate move for advance payment" default="true"/>
+        <!-- Invoice page -->
+        <boolean name="allowCancelVentilatedInvoice" title="Allow cancelation of ventilated invoice"/>
+        <boolean name="allowRemovalValidatedMove" title="Allow removal of validated move"/>
+        <boolean name="allowNonExportedMoveEditing" title="Allow editing unexported moves" default="false"
+                 help="Activate this option if you're using an external software for accounting and export data to it. Moves will be editable as long as they have not been exported even if validated"/>
+        <boolean name="generateMoveForInvoicePayment" title="Generate move for payment on invoice" default="true"/>
+        <boolean name="generateMoveForAdvancePayment" title="Generate move for advance payment" default="true"/>
 
-		<!-- Account chart template -->
-		<many-to-one name="accountChart" ref="com.axelor.apps.account.db.AccountChart" title="Account chart"/>
-		<boolean name="hasChartImported" title="Chart imported?"/>
-		<integer name="invoiceInAtiSelect" title="Invoice ATI/WT" selection="base.in.ati.select" default="1"/>
+        <!-- Account chart template -->
+        <many-to-one name="accountChart" ref="com.axelor.apps.account.db.AccountChart" title="Account chart"/>
+        <boolean name="hasChartImported" title="Chart imported?"/>
+        <integer name="invoiceInAtiSelect" title="Invoice ATI/WT" selection="base.in.ati.select" default="1"/>
 
-		<!-- Accounting Daybook (Mode brouillard) -->
-		<boolean name="accountingDaybook" title="Accounting Daybook"/>
+        <!-- Accounting Daybook (Mode brouillard) -->
+        <boolean name="accountingDaybook" title="Accounting Daybook"/>
 
-		<!-- Sequence -->
-		<many-to-one name="custInvSequence" ref="com.axelor.apps.base.db.Sequence" title="Customer invoices sequence"/>
-		<many-to-one name="custRefSequence" ref="com.axelor.apps.base.db.Sequence" title="Customer refunds sequence"/>
-		<many-to-one name="suppInvSequence" ref="com.axelor.apps.base.db.Sequence" title="Supplier invoices sequence"/>
-		<many-to-one name="suppRefSequence" ref="com.axelor.apps.base.db.Sequence" title="Supplier refunds sequence"/>
+        <!-- Sequence -->
+        <many-to-one name="custInvSequence" ref="com.axelor.apps.base.db.Sequence" title="Customer invoices sequence"/>
+        <many-to-one name="custRefSequence" ref="com.axelor.apps.base.db.Sequence" title="Customer refunds sequence"/>
+        <many-to-one name="suppInvSequence" ref="com.axelor.apps.base.db.Sequence" title="Supplier invoices sequence"/>
+        <many-to-one name="suppRefSequence" ref="com.axelor.apps.base.db.Sequence" title="Supplier refunds sequence"/>
 
-		<!--Product -->
+        <!--Product -->
 
-		<many-to-one name="invoicingProduct" title="Product to partially invoice sale order" ref="com.axelor.apps.base.db.Product"/>
-		<many-to-one name="advancePaymentProduct" title="Advance payment product" ref="com.axelor.apps.base.db.Product"/>
+        <many-to-one name="invoicingProduct" title="Product to partially invoice sale order" ref="com.axelor.apps.base.db.Product"/>
+        <many-to-one name="advancePaymentProduct" title="Advance payment product" ref="com.axelor.apps.base.db.Product"/>
 
-		<!-- Invoice printing -->
-		<boolean name="displayDelAddrOnPrinting" title="Display delivery address on printing ?"/>
-		<boolean name="displayProductCodeOnPrinting" title="Display product code on printing ?"/>
-		<boolean name="displayTaxDetailOnPrinting" title="Display tax detail on printing ?"/>
-		<string name="invoiceClientBox" large="true" multiline="true" title="Client box in invoice"/>
-		<string name="saleInvoiceLegalNote" large="true" multiline="true" title="Legal note on sale invoices" help="Short legal note to be displayed on sale invoices"/>
+        <!-- Invoice printing -->
+        <boolean name="displayDelAddrOnPrinting" title="Display delivery address on printing ?"/>
+        <boolean name="displayProductCodeOnPrinting" title="Display product code on printing ?"/>
+        <boolean name="displayTaxDetailOnPrinting" title="Display tax detail on printing ?"/>
+        <string name="invoiceClientBox" large="true" multiline="true" title="Client box in invoice"/>
+        <string name="saleInvoiceLegalNote" large="true" multiline="true" title="Legal note on sale invoices" help="Short legal note to be displayed on sale invoices"/>
 
-		<string name="termsAndConditions" large="true" title="Terms and Conditions"/>
+        <string name="termsAndConditions" large="true" title="Terms and Conditions"/>
 
-		<!-- Invoice mail -->
-		<boolean name="invoiceAutomaticMail" title="Send email on invoice ventilation" default="false"/>
-		<many-to-one name="invoiceMessageTemplate" title="Message template" ref="com.axelor.apps.message.db.Template"/>
+        <!-- Invoice mail -->
+        <boolean name="invoiceAutomaticMail" title="Send email on invoice ventilation" default="false"/>
+        <many-to-one name="invoiceMessageTemplate" title="Message template" ref="com.axelor.apps.message.db.Template"/>
 
-		<finder-method name="findByCompany" using="company"/>
+        <finder-method name="findByCompany" using="company"/>
 
-		<extra-code><![CDATA[
+        <extra-code><![CDATA[
 	
 	   	// TYPE SELECT
 		public static final int INVOICE_WT_ALWAYS = 1;
@@ -153,7 +155,7 @@
 	
 	]]></extra-code>
 
-	</entity>
+    </entity>
 
 </domain-models>
 

--- a/axelor-account/src/main/resources/views/AccountConfig.xml
+++ b/axelor-account/src/main/resources/views/AccountConfig.xml
@@ -19,6 +19,7 @@
 
 			<field name="hasChartImported"/>
 			<field name="allowRemovalValidatedMove"/>
+            <field name="allowNonExportedMoveEditing"/>
 			<field name="generateMoveForAdvancePayment"/>
 			<field name="accountingDaybook"/>
 			<field name="invoiceMessageTemplate" requiredIf="invoiceAutomaticMail" showIf="invoiceAutomaticMail" domain="self.metaModel.name = 'Invoice'"/>

--- a/axelor-account/src/main/resources/views/Move.xml
+++ b/axelor-account/src/main/resources/views/Move.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<object-views xmlns="http://axelor.com/xml/ns/object-views"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://axelor.com/xml/ns/object-views http://axelor.com/xml/ns/object-views/object-views_5.0.xsd">
-    
+<object-views xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns="http://axelor.com/xml/ns/object-views"
+              xsi:schemaLocation="http://axelor.com/xml/ns/object-views http://axelor.com/xml/ns/object-views/object-views_5.0.xsd">
+
     <grid name="move-grid" orderBy="-date" title="Account moves" model="com.axelor.apps.account.db.Move" canDelete="false">
         <toolbar>
-            <button name="validateMove" title="Validate" if="__repo__(AccountConfig).findByCompany(__user__.getActiveCompany()).getAccountingDaybook()" prompt="The validation of a move brings irrevocable integration of a move in Moves book" onClick="action-move-method-validate-multiple-moves"/>
+            <button name="validateMove" title="Validate" if="__repo__(AccountConfig).findByCompany(__user__.getActiveCompany()).getAccountingDaybook()"
+                    prompt="The validation of a move brings irrevocable integration of a move in Moves book" onClick="action-move-method-validate-multiple-moves"/>
             <button name="deleteMoves" title="Delete" prompt="Only 'Draft' moves can be deleted" icon="fa-trash" onClick="action-move-method-delete-multiple-moves"/>
-        	<button name="moveLines" title="See Move Lines" onClick="action-move-method-show-move-lines" />
+            <button name="moveLines" title="See Move Lines" onClick="action-move-method-show-move-lines"/>
         </toolbar>
-        
+
         <hilite color="info" if="statusSelect == 1"/>
         <hilite color="danger" if="statusSelect == 4"/>
         <field name="reference" width="200"/>
@@ -24,7 +25,8 @@
 
     <form name="move-form" title="Account move" model="com.axelor.apps.account.db.Move" canDelete="false" width="large"
           onNew="action-account-move-onnew-group"
-          onLoad="action-move-attrs-adjusting-move,action-move-attrs-hide-move-line-name-in-draft-status">
+          onLoad="action-account-move-onload-group"
+          onSave="action-account-move-onsave-group">
 
         <toolbar>
             <button name="print" title="Print Move" icon="fa-print" onClick="save,action-account-move-method-print-move"/>
@@ -32,8 +34,8 @@
             <button name="deleteMove" title="delete" icon="fa-trash" onClick="action-move-method-delete-move"/>
         </toolbar>
 
-        <panel name="main" readonlyIf="statusSelect == 3" colSpan="12">
-			<panel colSpan="9">
+        <panel name="main" readonlyIf="statusSelect == 3 &amp;&amp; $allowNonExportedMoveEditing == false" colSpan="12">
+            <panel colSpan="9">
                 <field name="reference" colSpan="12"/>
                 <panel readonlyIf="moveLineList.length &gt; 0" colSpan="12">
                     <field name="company" canEdit="false" widget="SuggestBox" onChange="action-move-method-get-period" form-view="company-form" grid-view="company-grid"/>
@@ -66,12 +68,18 @@
                 <field name="getInfoFromFirstMoveLineOk" colSpan="12" hideIf="statusSelect >= 3"/>
                 <field name="validationDate" readonly="true" showIf="statusSelect == 3"/>
 
-                <button name="validate" title="Validate" onClick="action-group-account-move-validate-click" colSpan="12" hideIf="statusSelect >= 3" if="!__user__.activeCompany?.accountConfig?.accountingDaybook"/>
-                <button name="account" title="Accounting.toAccount" onClick="action-group-account-move-account-click" colSpan="12" hideIf="statusSelect >= 2" if="__user__.activeCompany?.accountConfig?.accountingDaybook"/>
+                <button name="validate" title="Validate" onClick="action-group-account-move-validate-click" colSpan="12" hideIf="statusSelect >= 3"
+                        if="!__user__.activeCompany?.accountConfig?.accountingDaybook"/>
+                <button name="account" title="Accounting.toAccount" onClick="action-group-account-move-account-click" colSpan="12" hideIf="statusSelect >= 2"
+                        if="__user__.activeCompany?.accountConfig?.accountingDaybook"/>
+
+                <!-- Dummy field holding corresponding configuration for this company's move -->
+                <field name="$allowNonExportedMoveEditing" hidden="true"/>
             </panel>
-		</panel>
-		
-		<panel-related field="moveLineList" showIf="journal &amp;&amp; company &amp;&amp; date &amp;&amp; period" readonlyIf="statusSelect == 3" grid-view="move-line-move-grid" form-view="move-line-move-form"/>
+        </panel>
+
+        <panel-related field="moveLineList" showIf="journal &amp;&amp; company &amp;&amp; date &amp;&amp; period" readonlyIf="statusSelect == 3 &amp;&amp; $allowNonExportedMoveEditing == false"
+                       grid-view="move-line-move-grid" form-view="move-line-move-form"/>
 
         <panel-tabs>
             <panel name="relatedTo" title="Related to" readonly="true">
@@ -100,131 +108,155 @@
             </panel>
         </panel-tabs>
     </form>
-	
-	<!-- ACTION GROUPs -->
-	<action-group name="action-account-move-onnew-group">
-		<action name="default-move-record"/>
-		<action name="default-move-record-currency"/>
-		<action name="action-move-record-journal"/>
-		<action name="action-move-method-get-period"/>
-		<action name="action-move-attrs-adjusting-move"/>
-		<action name="action-move-attrs-hide-move-line-name-in-draft-status"/>
-	</action-group>
-	
-	<action-group name="action-group-account-move-validate-click">
-		<action name="save"/>
-		<action name="action-move-method-validate"/>
-		<action name="save"/>
-	</action-group>
 
-	<action-group name="action-group-account-move-account-click">
-		<action name="save"/>
-		<action name="action-move-method-account"/>
-		<action name="save"/>
-	</action-group>
+    <!-- ACTION GROUPs -->
+    <action-group name="action-account-move-onnew-group">
+        <action name="default-move-record"/>
+        <action name="default-move-record-currency"/>
+        <action name="action-move-record-journal"/>
+        <action name="action-move-method-get-period"/>
+        <action name="action-move-attrs-adjusting-move"/>
+        <action name="action-move-attrs-hide-move-line-name-in-draft-status"/>
+        <action name="action-move-record-load-dummy-fields"/>
+    </action-group>
 
-   	<!-- ACTION RECORD -->
+    <action-group name="action-account-move-onload-group">
+        <action name="action-move-attrs-adjusting-move"/>
+        <action name="action-move-attrs-hide-move-line-name-in-draft-status"/>
+        <action name="action-move-record-load-dummy-fields"/>
+    </action-group>
+
+    <action-group name="action-account-move-onsave-group">
+        <action name="action-move-method-validate-equiponderante-move" if="statusSelect == 3 &amp;&amp; company.accountConfig.allowNonExportedMoveEditing &amp;&amp; accountingOk == false"/>
+        <action name="action-move-method-update-partner-account" if="statusSelect == 3 &amp;&amp; company.accountConfig.allowNonExportedMoveEditing &amp;&amp; accountingOk == false"/>
+    </action-group>
+
+    <action-group name="action-group-account-move-validate-click">
+        <action name="save"/>
+        <action name="action-move-method-validate"/>
+        <action name="save"/>
+    </action-group>
+
+    <action-group name="action-group-account-move-account-click">
+        <action name="save"/>
+        <action name="action-move-method-account"/>
+        <action name="save"/>
+    </action-group>
+
+    <!-- ACTION RECORD -->
     <action-record name="default-move-record" model="com.axelor.apps.account.db.Move">
-		<field name="company"  expr="eval:__user__.activeCompany" if="__user__.activeCompany != null"/>
-    	<field name="company"  expr="eval:__repo__(Company).all().fetchOne()" if="__user__.activeCompany == null &amp;&amp; __repo__(Company).all().fetch().size == 1"/>
-		<field name="getInfoFromFirstMoveLineOk" expr="eval: true"/>
-		<field name="date" expr="eval:__config__.app.getTodayDate()" if="date == null"/>
-		<field name="technicalOriginSelect" expr="1"/>
+        <field name="company" expr="eval:__user__.activeCompany" if="__user__.activeCompany != null"/>
+        <field name="company" expr="eval:__repo__(Company).all().fetchOne()" if="__user__.activeCompany == null &amp;&amp; __repo__(Company).all().fetch().size == 1"/>
+        <field name="getInfoFromFirstMoveLineOk" expr="eval: true"/>
+        <field name="date" expr="eval:__config__.app.getTodayDate()" if="date == null"/>
+        <field name="technicalOriginSelect" expr="1"/>
     </action-record>
-    
+
     <action-record name="default-move-record-currency" model="com.axelor.apps.account.db.Move">
-		<field name="companyCurrency" expr="eval: company?.currency" />
-		<field name="currency" expr="eval: company?.currency" />
-		<field name="currencyCode" expr="eval: company?.currency.code" />
+        <field name="companyCurrency" expr="eval: company?.currency"/>
+        <field name="currency" expr="eval: company?.currency"/>
+        <field name="currencyCode" expr="eval: company?.currency.code"/>
     </action-record>
 
     <action-record name="action-move-record-journal" model="com.axelor.apps.account.db.Move">
-    	<field name="journal" expr="eval: company?.accountConfig?.manualMiscOpeJournal"/>
+        <field name="journal" expr="eval: company?.accountConfig?.manualMiscOpeJournal"/>
     </action-record>
-    
-	<!-- ACTION ATTRS -->
-	<action-attrs name="action-move-attrs-set-domain-payment-mode">
-	  <attribute name="domain" for="paymentMode" expr="eval: &quot; self.id IN (SELECT am.paymentMode FROM AccountManagement am WHERE am.company = :company)  &quot;"/>
-	</action-attrs>
 
-	<action-attrs name="action-move-attrs-adjusting-move">
-		<attribute for="adjustingMove" name="readonly" expr="eval: period.statusSelect != 3" if="eval: statusSelect &lt; 3"/>
-		<attribute for="adjustingMove" name="readonly" expr="true" if="eval: statusSelect &gt; 2"/>
-	</action-attrs>
+    <action-record name="action-move-record-load-dummy-fields" model="com.axelor.apps.account.db.Move">
+        <field name="$allowNonExportedMoveEditing" expr="eval: company?.accountConfig?.allowNonExportedMoveEditing &amp;&amp; accountingOk == false"/>
+    </action-record>
 
-	<action-attrs name="action-move-attrs-hide-move-line-name-in-draft-status">
-		<attribute name="hidden" for="moveLineList.counter" expr="eval: statusSelect == null || statusSelect == 1"/>
-		<attribute name="hidden" for="moveLineList.amountRemaining" expr="eval: statusSelect == null || statusSelect == 1"/>
-	</action-attrs>
-	
-	<!-- ACTION METHOD -->
-	<action-method name="action-move-method-validate">
-		<call class="com.axelor.apps.account.web.MoveController" method="validate"/>
-	</action-method>
+    <!-- ACTION ATTRS -->
+    <action-attrs name="action-move-attrs-set-domain-payment-mode">
+        <attribute name="domain" for="paymentMode" expr="eval: &quot; self.id IN (SELECT am.paymentMode FROM AccountManagement am WHERE am.company = :company)  &quot;"/>
+    </action-attrs>
 
-	<action-method name="action-move-method-account">
-		<call class="com.axelor.apps.account.web.MoveController" method="account"/>
-	</action-method>
+    <action-attrs name="action-move-attrs-adjusting-move">
+        <attribute for="adjustingMove" name="readonly" expr="eval: period.statusSelect != 3" if="eval: statusSelect &lt; 3"/>
+        <attribute for="adjustingMove" name="readonly" expr="true" if="eval: statusSelect &gt; 2"/>
+    </action-attrs>
 
-	<action-method name="action-move-method-generate-reverse-move">
-		<call class="com.axelor.apps.account.web.MoveController" method="generateReverse"/> 
-	</action-method>
-	
-	<action-method name="action-move-method-get-period">
-		<call class="com.axelor.apps.account.web.MoveController" method="getPeriod"/>
-	</action-method>
-	
-	<action-method name="action-move-method-validate-multiple-moves">
-	    <call class="com.axelor.apps.account.web.MoveController" method="validateMultipleMoves"/>
-	</action-method>
-	
-	<action-method name="action-move-method-delete-multiple-moves">
-	    <call class="com.axelor.apps.account.web.MoveController" method="deleteMultipleMoves"/>
-	</action-method>
-	
-	<action-method name="action-move-method-delete-move">
-	    <call class="com.axelor.apps.account.web.MoveController" method="deleteMove"/>
-	</action-method>
-	
-	<action-method name="action-move-method-show-move-lines">
-		<call class="com.axelor.apps.account.web.MoveController" method="showMoveLines"/>
-	</action-method>
+    <action-attrs name="action-move-attrs-hide-move-line-name-in-draft-status">
+        <attribute name="hidden" for="moveLineList.counter" expr="eval: statusSelect == null || statusSelect == 1"/>
+        <attribute name="hidden" for="moveLineList.amountRemaining" expr="eval: statusSelect == null || statusSelect == 1"/>
+    </action-attrs>
 
-	<action-method name="action-account-move-method-print-move">
-		<call class="com.axelor.apps.account.web.MoveController" method="printMove"/>
-	</action-method>
-	
-	<search-filters name="move-filters" model="com.axelor.apps.account.db.Move" title="Move filters">
-		<filter title="Current Period Entries">
-			<domain>self.period IS NULL OR (CURRENT_DATE &gt;= self.period.fromDate and CURRENT_DATE &lt;= self.period.toDate)</domain>
-		</filter>
-		<filter title="Exported moves">
-			<domain>self.accountingOk = true</domain>
-		</filter>
-		<filter title="Moves to export">
-			<domain>self.ignoreInAccountingOk = false AND self.journal.notExportOk = false AND self.accountingOk = false</domain>
-		</filter>
-		<filter title="Moves from invoices/refunds">
-			<domain>self.invoice IS NOT NULL</domain>
-		</filter>
-		<filter title="Moves from payment">
-			<domain>self.paymentMode IS NOT NULL</domain>
-		</filter>
-		<filter title="Misc. Moves">
-			<domain>self.date IS NOT NULL</domain>
-		</filter>
-		<filter title="Draft Moves">
-			<domain>self.statusSelect = 1</domain>
-		</filter>
-		<filter title="Simulated Moves">
-			<domain>self.statusSelect = 2</domain>
-		</filter>
-		<filter title="Validated Moves">
-			<domain>self.statusSelect = 3</domain>
-		</filter>
-		<filter title="Canceled Moves">
-			<domain>self.statusSelect = 4</domain>
-		</filter>
-	</search-filters>
-   
+    <!-- ACTION METHOD -->
+    <action-method name="action-move-method-validate">
+        <call class="com.axelor.apps.account.web.MoveController" method="validate"/>
+    </action-method>
+
+    <action-method name="action-move-method-account">
+        <call class="com.axelor.apps.account.web.MoveController" method="account"/>
+    </action-method>
+
+    <action-method name="action-move-method-generate-reverse-move">
+        <call class="com.axelor.apps.account.web.MoveController" method="generateReverse"/>
+    </action-method>
+
+    <action-method name="action-move-method-get-period">
+        <call class="com.axelor.apps.account.web.MoveController" method="getPeriod"/>
+    </action-method>
+
+    <action-method name="action-move-method-validate-multiple-moves">
+        <call class="com.axelor.apps.account.web.MoveController" method="validateMultipleMoves"/>
+    </action-method>
+
+    <action-method name="action-move-method-delete-multiple-moves">
+        <call class="com.axelor.apps.account.web.MoveController" method="deleteMultipleMoves"/>
+    </action-method>
+
+    <action-method name="action-move-method-delete-move">
+        <call class="com.axelor.apps.account.web.MoveController" method="deleteMove"/>
+    </action-method>
+
+    <action-method name="action-move-method-show-move-lines">
+        <call class="com.axelor.apps.account.web.MoveController" method="showMoveLines"/>
+    </action-method>
+
+    <action-method name="action-account-move-method-print-move">
+        <call class="com.axelor.apps.account.web.MoveController" method="printMove"/>
+    </action-method>
+
+    <action-method name="action-move-method-validate-equiponderante-move">
+        <call class="com.axelor.apps.account.web.MoveController" method="validateConsistency"/>
+    </action-method>
+
+    <action-method name="action-move-method-update-partner-account">
+        <call class="com.axelor.apps.account.web.MoveController" method="updatePartnerAccount"/>
+    </action-method>
+
+    <search-filters name="move-filters" model="com.axelor.apps.account.db.Move" title="Move filters">
+        <filter title="Current Period Entries">
+            <domain>self.period IS NULL OR (CURRENT_DATE &gt;= self.period.fromDate and CURRENT_DATE &lt;= self.period.toDate)</domain>
+        </filter>
+        <filter title="Exported moves">
+            <domain>self.accountingOk = true</domain>
+        </filter>
+        <filter title="Moves to export">
+            <domain>self.ignoreInAccountingOk = false AND self.journal.notExportOk = false AND self.accountingOk = false</domain>
+        </filter>
+        <filter title="Moves from invoices/refunds">
+            <domain>self.invoice IS NOT NULL</domain>
+        </filter>
+        <filter title="Moves from payment">
+            <domain>self.paymentMode IS NOT NULL</domain>
+        </filter>
+        <filter title="Misc. Moves">
+            <domain>self.date IS NOT NULL</domain>
+        </filter>
+        <filter title="Draft Moves">
+            <domain>self.statusSelect = 1</domain>
+        </filter>
+        <filter title="Simulated Moves">
+            <domain>self.statusSelect = 2</domain>
+        </filter>
+        <filter title="Validated Moves">
+            <domain>self.statusSelect = 3</domain>
+        </filter>
+        <filter title="Canceled Moves">
+            <domain>self.statusSelect = 4</domain>
+        </filter>
+    </search-filters>
+
 </object-views>


### PR DESCRIPTION
Add a new option to allow editing validated account moves as long as
they haven't been exported. This allows to be more flexible when an
external accouting software is used.
This works around the fact that the accountingDayBook option is almost
never used (and the code flow in the invoicing system is such a maze
that this can not be fixed on a short term).