### PR TITLE
PaymentVoucher: fix display of confirm button for credit card payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Purchase Order: remove save on loading purchase order form.
 - Stock Chart: fix wrong action name.
 - App Sale: fix unresolved action error.
+- Payment voucher: fix confirm button display on credit card supplier payments.
 
 ## [5.0.7] - 2018-12-13
 ## Features

--- a/axelor-account/src/main/resources/views/PaymentVoucher.xml
+++ b/axelor-account/src/main/resources/views/PaymentVoucher.xml
@@ -178,7 +178,7 @@
 	</action-attrs>
 	
    	<action-attrs name="action-pv-hide-confirm-button">
-   		<attribute name="hidden" for="confirmPaymentVoucher" expr="eval: statusSelect > __repo__(PaymentVoucher).STATUS_DRAFT || (!payboxPaidOk &amp;&amp; paymentMode?.typeSelect == 6)"/>
+		<attribute name="hidden" for="confirmPaymentVoucher" expr="eval: statusSelect > __repo__(PaymentVoucher).STATUS_DRAFT || (!payboxPaidOk &amp;&amp; paymentMode?.typeSelect == 6 &amp;&amp; operationTypeSelect == 3)"/>
    	</action-attrs>
    	
 	<action-attrs name="action-attrs-payment-voucher-hidden-receipt">


### PR DESCRIPTION
Button was hidden for supplier payments when it shouldn't