### PR TITLE
i18n: remove wrong fiscal position translation

### DIFF
--- a/axelor-contract/src/main/resources/i18n/messages_fr.csv
+++ b/axelor-contract/src/main/resources/i18n/messages_fr.csv
@@ -78,7 +78,7 @@
 "Error","Erreur",,
 "First period end date","Fin de la première période",,
 "First period invoicing end date","Première période de fin de facturation",,
-"Fiscal position","Position fiscal",,
+"Fiscal position",,,
 "Full name","Nom complet",,
 "General","Général",,
 "Information",,,


### PR DESCRIPTION
It was overriding the axelor-account module one with a typo.