### PR TITLE
fixedAssets: create from invoice when category is filled

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/FixedAssetServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/FixedAssetServiceImpl.java
@@ -154,8 +154,7 @@ public class FixedAssetServiceImpl implements FixedAssetService {
               invoiceLine.getProductName());
         }
 
-        if (accountConfig.getFixedAssetCatReqOnInvoice()
-            && invoiceLine.getFixedAssets()
+        if (invoiceLine.getFixedAssets()
             && invoiceLine.getFixedAssetCategory() != null) {
 
           FixedAsset fixedAsset = new FixedAsset();


### PR DESCRIPTION
Do not check whether config flag fixedAssetCatReqOnInvoice is set to
create the fixed asset. If user filled the category it is likely that he
wants to create the asset. Moreover the label of the option does not
indicate in any way that setting it to false will prevent any automatic
fixed asset creation.