### PR TITLE
Link batch to generated bank order

### DIFF
--- a/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/service/batch/BatchDirectDebitCustomerInvoice.java
+++ b/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/service/batch/BatchDirectDebitCustomerInvoice.java
@@ -22,6 +22,7 @@ import com.axelor.apps.account.db.Invoice;
 import com.axelor.apps.account.db.InvoicePayment;
 import com.axelor.apps.account.db.repo.InvoiceRepository;
 import com.axelor.apps.account.service.payment.invoice.payment.InvoicePaymentCreateService;
+import com.axelor.apps.bankpayment.db.BankOrder;
 import com.axelor.apps.bankpayment.service.bankorder.BankOrderMergeService;
 import com.axelor.apps.base.db.BankDetails;
 import com.axelor.apps.base.db.repo.BankDetailsRepository;
@@ -104,7 +105,8 @@ public class BatchDirectDebitCustomerInvoice extends BatchDirectDebit {
 
     if (!invoicePaymentList.isEmpty()) {
       try {
-        Beans.get(BankOrderMergeService.class).mergeFromInvoicePayments(invoicePaymentList);
+        final BankOrder bankOrder = Beans.get(BankOrderMergeService.class).mergeFromInvoicePayments(invoicePaymentList);
+        findBatch().setBankOrder(bankOrder);
       } catch (AxelorException e) {
         TraceBackService.trace(e, IException.DIRECT_DEBIT, batch.getId());
         LOG.error(e.getMessage());


### PR DESCRIPTION
"Create bank order" button on the batch form should only be shown when
there is no bank order generated from the batch.