### PR TITLE
Upgrade Bouncy Castle dependencies

### DIFF
--- a/axelor-account/build.gradle
+++ b/axelor-account/build.gradle
@@ -19,6 +19,6 @@ dependencies {
 
 	compile group: 'jdom', name: 'jdom', version: '1.1'
 	compile group: 'org.apache.xmlbeans', name: 'xmlbeans', version: '2.5.0'
-	compile "org.bouncycastle:bcprov-jdk15:1.46"
-
+    compile "org.bouncycastle:bcprov-jdk15on:1.62"
+    compile "org.bouncycastle:bcpkix-jdk15on:1.62"
 }

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/payment/PayboxService.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/payment/PayboxService.java
@@ -53,7 +53,7 @@ import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.codec.Base64;
-import org.bouncycastle.openssl.PEMReader;
+import org.bouncycastle.openssl.PEMParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -462,12 +462,11 @@ public class PayboxService {
    * @throws Exception
    */
   private PublicKey getPubKey(String pubKeyPath) throws Exception {
+    final byte[] pubKey;
 
-    PEMReader reader = new PEMReader(new FileReader(pubKeyPath));
-
-    byte[] pubKey = ((X509EncodedKeySpec) reader.readObject()).getEncoded();
-
-    reader.close();
+    try (final PEMParser reader = new PEMParser(new FileReader(pubKeyPath))) {
+      pubKey = ((X509EncodedKeySpec) reader.readObject()).getEncoded();
+    }
 
     KeyFactory keyFactory = KeyFactory.getInstance(this.ENCRYPTION_ALGORITHM);
 

--- a/axelor-bank-payment/build.gradle
+++ b/axelor-bank-payment/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     	 'javax.xml.bind:jaxb-api:2.2.2'
 
 	compile files("src/main/lib/ebics-1.0.2.jar")
-	compile "org.bouncycastle:bcprov-jdk15:1.46"
+	compile "org.bouncycastle:bcprov-jdk15on:1.62"
 	compile "org.apache.santuario:xmlsec:1.4.3"
 	compile "commons-codec:commons-codec:1.11"
 }

--- a/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/ebics/certificate/KeyStoreManager.java
+++ b/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/ebics/certificate/KeyStoreManager.java
@@ -34,7 +34,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
-import org.bouncycastle.openssl.PEMReader;
+import org.bouncycastle.openssl.PEMParser;
 
 /**
  * Key store loader. This class loads a key store from a given path and allow to get private keys
@@ -129,9 +129,9 @@ public class KeyStoreManager {
             CertificateFactory.getInstance("X.509", provider).generateCertificate(input);
 
     if (certificate == null) {
-      PEMReader reader = new PEMReader(new InputStreamReader(input));
-      certificate = (X509Certificate) (reader).readObject();
-      reader.close();
+      try (final PEMParser reader = new PEMParser(new InputStreamReader(input))) {
+        certificate = (X509Certificate) (reader).readObject();
+      }
     }
 
     return certificate;

--- a/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/ebics/service/EbicsCertificateService.java
+++ b/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/ebics/service/EbicsCertificateService.java
@@ -54,7 +54,7 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.bouncycastle.openssl.PEMReader;
+import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.PEMWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -304,9 +304,9 @@ public class EbicsCertificateService {
 
     X509Certificate cert = null;
     StringReader reader = new StringReader(pemString);
-    PEMReader pr = new PEMReader(reader);
-    cert = (X509Certificate) pr.readObject();
-    pr.close();
+    try (final PEMParser pr = new PEMParser(reader)) {
+      cert = (X509Certificate) pr.readObject();
+    }
 
     return cert;
   }

--- a/axelor-base/build.gradle
+++ b/axelor-base/build.gradle
@@ -22,5 +22,5 @@ dependencies {
 	compile "org.mnode.ical4j:ical4j-connector:1.0.1"
 	compile "com.google.zxing:core:3.3.2"
 	compile 'org.iban4j:iban4j:3.2.1'
-	compile 'com.itextpdf:itextpdf:5.0.6'
+	compile 'com.itextpdf:itextpdf:5.5.13.1'
 }

--- a/axelor-studio/build.gradle
+++ b/axelor-studio/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 //	compile 'org.xhtmlrenderer:flying-saucer-pdf:9.1.4'
 	compile 'org.eclipse.birt.runtime.3_7_1:Tidy:1'
 	compile 'org.apache.commons:commons-exec:1.2'
-//	compile "org.bouncycastle:bcprov-jdk14:1.38"
+//	compile "org.bouncycastle:bcprov-jdk15on:1.62"
 }
 
 def updateJsp(jspFile, check, lines) {


### PR DESCRIPTION
Upgrade Bouncy Castle dependencies in order to consistently use
"bcprov-jdk15on" and "bcpkix-jdk15on" modules.

Addresses RM-19229