### PR TITLE
Fix random NPE when sending emails asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,7 @@
 - RawMaterialRequirement report: fix sql query.
 - Improve exception handling in leave request form.
 - TaxLine: tax field is now readonly and cannot be edited when selected.
+- Message: fix random NPE when sending emails asynchronously.
 
 ## [5.1.7] - 2019-06-17
 ## Features

--- a/axelor-base/src/main/java/com/axelor/apps/base/service/message/TemplateMessageServiceBaseImpl.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/service/message/TemplateMessageServiceBaseImpl.java
@@ -155,9 +155,7 @@ public class TemplateMessageServiceBaseImpl extends TemplateMessageServiceImpl {
         reportSettings.addParam(
             birtTemplateParameter.getName(),
             convertValue(birtTemplateParameter.getType(), maker.make()));
-
-        reportSettings.generate();
-      } catch (AxelorException | BirtException e) {
+      } catch (BirtException e) {
         throw new AxelorException(
             e.getCause(),
             TraceBackRepository.CATEGORY_CONFIGURATION_ERROR,
@@ -165,6 +163,7 @@ public class TemplateMessageServiceBaseImpl extends TemplateMessageServiceImpl {
       }
     }
 
+    reportSettings.generate();
     return reportSettings;
   }
 

--- a/axelor-message/src/main/java/com/axelor/apps/message/service/MessageServiceImpl.java
+++ b/axelor-message/src/main/java/com/axelor/apps/message/service/MessageServiceImpl.java
@@ -316,6 +316,9 @@ public class MessageServiceImpl implements MessageService {
       mailBuilder.attach(metaFile.getFileName(), MetaFiles.getPath(metaFile).toString());
     }
 
+    // Make sure message can be found in sending thread below.
+    JPA.flush();
+
     // send email using a separate process to avoid thread blocking
     executor.submit(
         new Callable<Boolean>() {


### PR DESCRIPTION
Use JPA.flush() in order to make sure the message can be found in the
email sending thread.

Also generate report only after adding all parameters.

Addresses RM-19679