### PR TITLE
RM20753: fix WAP computation on customer returns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - PROJECT : Fixing financial report to follow the Axelor report guidelines
 
 ## Bug Fixes
+- Stock Move: fix WAP computation on customer returns.
 
 ## [5.1.8] - 2019-09-26
 ## Features

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveLineService.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveLineService.java
@@ -258,4 +258,12 @@ public interface StockMoveLineService {
 
   public List<TrackingNumber> getAvailableTrackingNumbers(
       StockMoveLine stockMoveLine, StockMove stockMove);
+
+  /**
+   * Fill realize avg price in stock move line. This method is called on realize, to save avg price
+   * at the time of realization.
+   *
+   * @param stockMoveLine a stock move line being realized.
+   */
+  public void fillRealizeWapPrice(StockMoveLine stockMoveLine);
 }

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveLineServiceImpl.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveLineServiceImpl.java
@@ -490,7 +490,11 @@ public class StockMoveLineServiceImpl implements StockMoveLineService {
       StockLocationLine stockLocationLine, StockMoveLine stockMoveLine) throws AxelorException {
     BigDecimal oldAvgPrice = stockLocationLine.getAvgPrice();
     BigDecimal oldQty = stockLocationLine.getCurrentQty();
-    BigDecimal newPrice = stockMoveLine.getCompanyUnitPriceUntaxed();
+    // avgPrice in stock move line is a bigdecimal but is nullable.
+    BigDecimal newPrice =
+        stockMoveLine.getWapPrice() != null
+            ? stockMoveLine.getWapPrice()
+            : stockMoveLine.getCompanyUnitPriceUntaxed();
     BigDecimal newQty = stockMoveLine.getRealQty();
     BigDecimal newAvgPrice;
     if (oldAvgPrice == null
@@ -1180,5 +1184,13 @@ public class StockMoveLineServiceImpl implements StockMoveLineService {
             + " )";
     trackingNumbers = trackingNumberRepo.all().filter(domain).fetch();
     return trackingNumbers;
+  }
+
+  public void fillRealizeWapPrice(StockMoveLine stockMoveLine) {
+    StockLocation stockLocation = stockMoveLine.getStockMove().getFromStockLocation();
+    StockLocationLine stockLocationLine =
+        stockLocationLineService.getStockLocationLine(stockLocation, stockMoveLine.getProduct());
+
+    stockMoveLine.setWapPrice(stockLocationLine.getAvgPrice());
   }
 }

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveServiceImpl.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveServiceImpl.java
@@ -381,6 +381,9 @@ public class StockMoveServiceImpl implements StockMoveService {
     String newStockSeq = null;
     stockMoveLineService.checkTrackingNumber(stockMove);
     stockMoveLineService.checkConformitySelection(stockMove);
+    if (stockMove.getFromStockLocation().getTypeSelect() != StockLocationRepository.TYPE_VIRTUAL) {
+      stockMove.getStockMoveLineList().forEach(stockMoveLineService::fillRealizeWapPrice);
+    }
     checkExpirationDates(stockMove);
 
     setRealizedStatus(stockMove);

--- a/axelor-stock/src/main/resources/domains/StockMoveLine.xml
+++ b/axelor-stock/src/main/resources/domains/StockMoveLine.xml
@@ -42,7 +42,9 @@
     <decimal name="unitPriceTaxed" precision="20" scale="10" title="Unit price"/>
     
     <decimal name="companyUnitPriceUntaxed" precision="20" scale="10" title="Company Unit price W.T."/>
-    
+
+    <decimal name="wapPrice" precision="20" scale="10" readonly="true" nullable="true" title="Price used for WAP"/>
+
     <string name="productTypeSelect" title="Product type" selection="product.product.type.select"/>
     <integer name="sequence" title="Seq."/>
 

--- a/axelor-stock/src/main/resources/i18n/messages.csv
+++ b/axelor-stock/src/main/resources/i18n/messages.csv
@@ -457,6 +457,7 @@
 "Please select the StockMove(s) to print.",,,
 "Please select the stock move(s) to print",,,
 "Please set an economic are in AppStock.",,,
+"Price used for WAP",,,
 "Print",,,
 "Print Incoming Move",,,
 "Print Internal Move",,,

--- a/axelor-stock/src/main/resources/i18n/messages_en.csv
+++ b/axelor-stock/src/main/resources/i18n/messages_en.csv
@@ -457,6 +457,7 @@
 "Please select the StockMove(s) to print.",,,
 "Please select the stock move(s) to print",,,
 "Please set an economic are in AppStock.",,,
+"Price used for WAP",,,
 "Print",,,
 "Print Incoming Move",,,
 "Print Internal Move",,,

--- a/axelor-stock/src/main/resources/i18n/messages_fr.csv
+++ b/axelor-stock/src/main/resources/i18n/messages_fr.csv
@@ -457,6 +457,7 @@
 "Please select the StockMove(s) to print.","Merci de sélectionner un Mouvement de stock à imprimer",,
 "Please select the stock move(s) to print",,,
 "Please set an economic are in AppStock.","Veuillez saisir une zone économique dans AppStock.",,
+"Price used for WAP","Prix utilisé pour le PMP",,
 "Print","Imprimer",,
 "Print Incoming Move","Imprimer le BR",,
 "Print Internal Move","Imprimer le transfert",,

--- a/axelor-stock/src/main/resources/views/StockMove.xml
+++ b/axelor-stock/src/main/resources/views/StockMove.xml
@@ -524,6 +524,7 @@
         <action name="action-stock-move-attrs-typeselect-change"/>
         <action name="action-stock-move-generate-invoice-button"/>
         <action name="action-stock-move-hide-reserved-qty"/>
+        <action name="action-stock-move-attrs-hide-avg-price"/>
         <action name="action-stock-move-attrs-set-required-shipment-supplier-details"/>
 		<action name="action-stock-move-attrs-filter-on-available-products"/>
     </action-group>
@@ -624,6 +625,10 @@
         <attribute for="stockMoveLineList.reservedQty" name="hidden" expr="eval: typeSelect != 2"/>
         <attribute name="hidden" for="stockMoveLineList.availableStatus" expr="eval: typeSelect == 3"/>
 	</action-attrs>
+
+    <action-attrs name="action-stock-move-attrs-hide-avg-price">
+        <attribute name="hidden" for="stockMoveLineList.wapPrice" expr="eval: typeSelect != 3 || !isReversion || !reversionOriginStockMove"/>
+    </action-attrs>
 	
     <action-method name="action-stock-move-method-draft" model="com.axelor.apps.stock.db.StockMove">
     	<call class="com.axelor.apps.stock.web.StockMoveController" method="draft"/>

--- a/axelor-stock/src/main/resources/views/StockMoveLine.xml
+++ b/axelor-stock/src/main/resources/views/StockMoveLine.xml
@@ -46,6 +46,7 @@
         <field name="netMass"
             onChange="action-stock-move-line-group-net-mass-onchange"
             width="100px"/>
+		<field name="wapPrice" x-scale="2" hidden="true"/>
         <field name="trackingNumber"
 			canNew="$get('stockMove.fromStockLocation.typeSelect') == 3 &amp;&amp; ($get('stockMove.toStockLocation.typeSelect') == 1 || $get('stockMove.toStockLocation.typeSelect') == 2)"
 			onSelect="action-stock-move-line-attrs-tracking-number-domain"
@@ -104,6 +105,7 @@
 					<field name="reservedQty" onChange="action-supplychain-attrs-stock-order-line-max-reserved-qty" readonly="true" if-module="axelor-supplychain" if="__config__.app.getApp('supplychain').getManageStockReservation()" colSpan="3"/>
 	        <field name="unitPriceUntaxed"/>
         	<field name="unitPriceTaxed" hidden="true"/>
+			<field name="wapPrice" hidden="true"/>
 	        <field name="unit" canEdit="false" colSpan="3" form-view="unit-form" grid-view="unit-grid"/>
     	    <field name="netMass" x-scale="5" onChange="action-stock-move-line-group-net-mass-onchange" colSpan="3"/>
 	        <field name="totalNetMass" readonly="true" showIf="totalNetMass" colSpan="3"/>
@@ -363,6 +365,7 @@
 		<action name="action-stock-move-line-attrs-scale-and-precision"/>
 		<action name="action-stock-move-line-tracking-number-attrs"/>
 		<action name="action-stock-move-line-qty-attrs"/>
+		<action name="action-stock-move-line-attrs-hide-avg-price"/>
 		<action name="action-stock-move-line-price-attrs-readonly" if="(__config__.app.isApp('sale') &amp;&amp; __config__.app.getApp('sale').getProductPackMgt())"/>
 		<action name="action-stock-move-subline-price-attrs-readonly" if="isSubLine &amp;&amp; (__config__.app.isApp('sale') &amp;&amp; __config__.app.getApp('sale').getProductPackMgt())"/>
 		<action name="action-stock-move-line-method-compute-available-qty" if="_parent?.statusSelect &lt; 3"/>
@@ -517,6 +520,7 @@
 
 	<action-attrs name="action-stock-move-line-attrs-scale-and-precision">
 		<attribute name="scale" for="unitPriceUntaxed" expr="eval: __config__.app.getNbDecimalDigitForUnitPrice()"/>
+		<attribute name="scale" for="wapPrice" expr="eval: __config__.app.getNbDecimalDigitForUnitPrice()"/>
 	</action-attrs>
 	
 	<action-view name="action-stock-move-line-product-default-planned" title="${fullName} plan. st. move"
@@ -585,6 +589,11 @@
     <attribute name="readonly" expr="__parent__?.pickingIsEdited" for="realQty"/>
     <attribute name="readonly" expr="__parent__?.pickingIsEdited" for="productModel"/>
   </action-attrs>
+
+	<action-attrs name="action-stock-move-line-attrs-hide-avg-price">
+		<attribute name="hidden" for="wapPrice" expr="eval: stockMove.typeSelect != 3 || !stockMove.isReversion || !stockMove.reversionOriginStockMove" if="stockMove"/>
+		<attribute name="hidden" for="wapPrice" expr="eval: __parent__.typeSelect != 3 || !__parent__.isReversion || !__parent__.reversionOriginStockMove" if="!stockMove"/>
+	</action-attrs>
 
 	<action-method name="action-stock-move-subline-method-reset-data-on-select-pack-line">
 		<call class="com.axelor.apps.supplychain.web.StockMoveLineController" method="resetSubLines"/>


### PR DESCRIPTION
Customer returns now have a new field that will be used to manage
weighted average price. This field contains the wap at the time of
realization of the customer delivery. Previously the price from customer
delivery was used for average price.